### PR TITLE
Set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ cache:
   - /tmp/texlive
   - $HOME/.texlive
   - /tmp/tlpkg
+  - doc/latex/pgfplots/figures/expensiveexamples
+  - doc/latex/pgfplots/gnuplot
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,30 @@ language: generic
 os: linux
 
 install:
-- cd ci/
-- source texlive.sh
-- cd ..
+  - cd ci/
+  - source texlive.sh
+  - cd ..
 
 cache:
   directories:
-  - /tmp/texlive
-  - $HOME/.texlive
-  - /tmp/tlpkg
-  - doc/latex/pgfplots/figures/expensiveexamples
-  - doc/latex/pgfplots/gnuplot
+    - /tmp/texlive
+    - $HOME/.texlive
+    - /tmp/tlpkg
+    - doc/latex/pgfplots/figures/expensiveexamples
+    - doc/latex/pgfplots/gnuplot
 
 addons:
   apt:
     packages:
-    - gnuplot
-    - realpath
+      - gnuplot
+      - realpath
 
 before_script:
-- git fetch --unshallow --tags
-- bash scripts/pgfplots/pgfplotsrevisionfile.sh
-- cat tex/generic/pgfplots/pgfplots.revision.tex
+  - git fetch --unshallow --tags
+  - bash scripts/pgfplots/pgfplotsrevisionfile.sh
+  - cat tex/generic/pgfplots/pgfplots.revision.tex
 
-script: |
+_build_manual: &_build_manual |
   set -e
   cd doc/latex/pgfplots
   while : ; do
@@ -35,7 +35,7 @@ script: |
   done
   cd -
 
-after_success: |
+_build_package: &_build_package |
   set -e
   mkdir -pv /tmp/gh-pages
   cp -v doc/latex/pgfplots/*.pdf /tmp/gh-pages
@@ -43,26 +43,31 @@ after_success: |
 
 jobs:
   include:
-  - env: engine=lualatex
-  - env: engine=pdflatex
+    - env: engine=lualatex
+      script: *_build_manual
+      after_success: *_build_package
+
+    - env: engine=pdflatex
+      script: *_build_manual
+      after_success: *_build_package
 
 deploy:
-- provider: pages
-  skip_cleanup: true
-  token: $GH_TOKEN
-  committer_from_gh: true
-  local_dir: /tmp/gh-pages
-  on:
-    branch: master
-    tags: false
-    condition: $engine = lualatex
-- provider: releases
-  skip_cleanup: true
-  token: $GH_TOKEN
-  file_glob: true
-  file:
-  - ../pgfplots_*
-  overwrite: true
-  on:
-    tags: true
-    condition: $engine = lualatex
+  - provider: pages
+    skip_cleanup: true
+    token: $GH_TOKEN
+    committer_from_gh: true
+    local_dir: /tmp/gh-pages
+    on:
+      branch: master
+      tags: false
+      condition: $engine = lualatex
+  - provider: releases
+    skip_cleanup: true
+    token: $GH_TOKEN
+    file_glob: true
+    file:
+      - ../pgfplots_*
+    overwrite: true
+    on:
+      tags: true
+      condition: $engine = lualatex

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ jobs:
     - cd doc/latex/pgfplots
     - make -j $(nproc) LATEX="lualatex -shell-escape -halt-on-error -interaction=nonstopmode"
 
-#  - env: engine=pdflatex
-#    script:
-#    - cd doc/latex/pgfplots
-#    - make LATEX="pdflatex -shell-escape -halt-on-error -interaction=nonstopmode"
+  - env: engine=pdflatex
+    script:
+    - cd doc/latex/pgfplots
+    - make -j $(nproc) LATEX="pdflatex -shell-escape -halt-on-error -interaction=nonstopmode"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ cache:
 addons:
   apt:
     packages:
-      - gnuplot
-      - realpath
+      - &base_deps
+        - gnuplot
+        - realpath
 
 before_script:
   - git fetch --unshallow --tags
@@ -41,15 +42,46 @@ _build_package: &_build_package |
   cp -v doc/latex/pgfplots/*.pdf /tmp/gh-pages
   make -C .. -f pgfplots/scripts/pgfplots/Makefile.pgfplots_release_sourceforge
 
+# FIXME:
+# Currently none of the testsuites work. Therfore `make' is followed by `true'
+# to set the exit status of the pipe to true. This has to be fixed to make this
+# actually usable, because right now this will just always pass.
+_build_tests: &_build_tests |
+  cd "source/latex/pgfplots/pgfplotstest/$suite"
+  make -j $(nproc) -k || true
+  grep -A2 '^!' *.log
+
 jobs:
   include:
-    - env: engine=lualatex
+    - name: Manual lualatex
+      env: engine=lualatex
       script: *_build_manual
       after_success: *_build_package
 
-    - env: engine=pdflatex
+    - name: Manual pdflatex
+      env: engine=pdflatex
       script: *_build_manual
       after_success: *_build_package
+
+    - name: Gallery
+      script: |
+        cd "doc/latex/pgfplots/gallery"
+        make -j $(nproc) -k
+        grep -A2 '^!' *.log
+
+#   - name: lua_tests
+#     env: suite=lua_tests
+#     addons: {apt: {packages: [*base_deps, lua5.2, lua-unit]}}
+#     script: *_build_tests
+
+    - name: regressiontests
+      env: suite=regressiontests
+      addons: {apt: {packages: [*base_deps, imagemagick]}}
+      script: *_build_tests
+
+    - name: unittest
+      env: suite=unittest
+      script: *_build_tests
 
 deploy:
   - provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: generic
+os: linux
+
+install:
+- cd ci/
+- source texlive.sh
+- cd ..
+
+cache:
+  directories:
+  - /tmp/texlive
+  - $HOME/.texlive
+  - /tmp/tlpkg
+
+addons:
+  apt:
+    packages:
+    - gnuplot
+    - realpath
+
+before_script:
+- git fetch --unshallow --tags
+- bash scripts/pgfplots/pgfplotsrevisionfile.sh
+- cat tex/generic/pgfplots/pgfplots.revision.tex
+
+jobs:
+  include:
+  - env: engine=lualatex
+    script:
+    - cd doc/latex/pgfplots
+    - make -j $(nproc) LATEX="lualatex -shell-escape -halt-on-error -interaction=nonstopmode"
+
+#  - env: engine=pdflatex
+#    script:
+#    - cd doc/latex/pgfplots
+#    - make LATEX="pdflatex -shell-escape -halt-on-error -interaction=nonstopmode"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
 - cat tex/generic/pgfplots/pgfplots.revision.tex
 
 script: |
+  set -e
   cd doc/latex/pgfplots
   while : ; do
     make -j $(nproc) LATEX="$engine -shell-escape -halt-on-error -interaction=nonstopmode"
@@ -34,7 +35,34 @@ script: |
   done
   cd -
 
+after_success: |
+  set -e
+  mkdir -pv /tmp/gh-pages
+  cp -v doc/latex/pgfplots/*.pdf /tmp/gh-pages
+  make -C .. -f pgfplots/scripts/pgfplots/Makefile.pgfplots_release_sourceforge
+
 jobs:
   include:
   - env: engine=lualatex
   - env: engine=pdflatex
+
+deploy:
+- provider: pages
+  skip_cleanup: true
+  token: $GH_TOKEN
+  committer_from_gh: true
+  local_dir: /tmp/gh-pages
+  on:
+    branch: master
+    tags: false
+    condition: $engine = lualatex
+- provider: releases
+  skip_cleanup: true
+  token: $GH_TOKEN
+  file_glob: true
+  file:
+  - ../pgfplots_*
+  overwrite: true
+  on:
+    tags: true
+    condition: $engine = lualatex

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,16 @@ before_script:
 - bash scripts/pgfplots/pgfplotsrevisionfile.sh
 - cat tex/generic/pgfplots/pgfplots.revision.tex
 
+script: |
+  cd doc/latex/pgfplots
+  while : ; do
+    make -j $(nproc) LATEX="$engine -shell-escape -halt-on-error -interaction=nonstopmode"
+    grep -q -E "(There were undefined references|Rerun to get (cross-references|the bars) right)" *.log || break
+    [ "$(( thisrun=$(( thisrun + 1 )) ))" -lt 5 ] || { echo "Reruns exceeded"; exit 1; }
+  done
+  cd -
+
 jobs:
   include:
   - env: engine=lualatex
-    script:
-    - cd doc/latex/pgfplots
-    - make -j $(nproc) LATEX="lualatex -shell-escape -halt-on-error -interaction=nonstopmode"
-
   - env: engine=pdflatex
-    script:
-    - cd doc/latex/pgfplots
-    - make -j $(nproc) LATEX="pdflatex -shell-escape -halt-on-error -interaction=nonstopmode"
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pgfplots
 
+[![Travis Build Status][travis-svg]][travis-link]
+
 pgfplots - Create normal/logarithmic plots in two and three dimensions for LaTeX/TeX/ConTeXt.
 
 pgfplotstable - Loads, rounds, formats and postprocesses numerical tables.
@@ -39,3 +41,6 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+[travis-svg]: https://travis-ci.com/pgf-tikz/pgfplots.svg?branch=master
+[travis-link]: https://travis-ci.com/pgf-tikz/pgfplots

--- a/ci/texlive.profile
+++ b/ci/texlive.profile
@@ -1,0 +1,10 @@
+selected_scheme scheme-infraonly
+TEXDIR /tmp/texlive
+TEXMFCONFIG ~/.texlive/texmf-config
+TEXMFHOME ~/texmf
+TEXMFLOCAL /tmp/texlive/texmf-local
+TEXMFSYSCONFIG /tmp/texlive/texmf-config
+TEXMFSYSVAR /tmp/texlive/texmf-var
+TEXMFVAR ~/.texlive/texmf-var
+option_doc 0
+option_src 0

--- a/ci/texlive.sh
+++ b/ci/texlive.sh
@@ -12,6 +12,9 @@ if ! command -v texlua > /dev/null; then
   # Install a minimal system
   ./install-tl --profile=../texlive.profile
 
+  # Bump up the main memory
+  echo "main_memory = 12435455" >> /tmp/texlive/texmf.cnf
+
   cd ..
 fi
 

--- a/ci/texlive.sh
+++ b/ci/texlive.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env sh
+
+export PATH=/tmp/texlive/bin/x86_64-linux:$PATH
+
+# Check for cached version
+if ! command -v texlua > /dev/null; then
+  # Obtain TeX Live
+  curl -LO http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+  tar -xzf install-tl-unx.tar.gz
+  cd install-tl-20*
+
+  # Install a minimal system
+  ./install-tl --profile=../texlive.profile
+
+  cd ..
+fi
+
+# Update infra first
+tlmgr update --self
+
+# Add tlcontrib
+tlmgr repository add http://contrib.texlive.info/current tlcontrib || true
+tlmgr pinning add tlcontrib "*"
+
+# Install all the required packages
+tlmgr install \
+    accsupp \
+    acrotex \
+    amsfonts \
+    amsmath \
+    atbegshi \
+    atveryend \
+    auxhook \
+    bibtex \
+    bitset \
+    booktabs \
+    colortbl \
+    conv-xkv \
+    ec \
+    epstopdf-pkg \
+    etex-pkg \
+    etexcmds \
+    etoolbox \
+    eurosym \
+    geometry \
+    german \
+    graphics \
+    hycolor \
+    hyperref \
+    ifoddpage \
+    iftex \
+    infwarerr \
+    intcalc \
+    kvdefinekeys \
+    kvoptions \
+    kvsetkeys \
+    l3kernel \
+    l3packages \
+    latex \
+    latex-bin \
+    letltxmacro \
+    listings \
+    ltxcmds \
+    luacode \
+    luainputenc \
+    luatex \
+    luatex85 \
+    luatexbase \
+    luatodonotes \
+    makeindex \
+    metafont \
+    mfware \
+    multirow \
+    pdfescape \
+    pdflscape \
+    pdftexcmds \
+    pgf \
+    pgfplots \
+    psnfss \
+    soul \
+    soulpos \
+    todonotes \
+    tools \
+    units \
+    url \
+    vmargin \
+    xcolor \
+    xkeyval \
+    xstring \
+    zref
+
+# Keep no backups (not required, simply makes cache bigger)
+tlmgr option -- autobackup 0
+
+# Update the TL install but add nothing new
+tlmgr update --self --all --no-auto-install
+
+# Install PGF
+tlmgr init-usertree --usertree `realpath ..`
+export TEXMFHOME=`realpath ..`

--- a/ci/texlive.sh
+++ b/ci/texlive.sh
@@ -73,19 +73,24 @@ tlmgr install \
     makeindex \
     metafont \
     mfware \
+    multido \
     multirow \
     pdfescape \
     pdflscape \
     pdftexcmds \
     pgf \
     pgfplots \
+    preview \
     psnfss \
+    shellesc \
     soul \
     soulpos \
+    standalone \
     todonotes \
     tools \
     units \
     url \
+    varwidth \
     vmargin \
     xcolor \
     xkeyval \

--- a/doc/latex/pgfplots/Makefile
+++ b/doc/latex/pgfplots/Makefile
@@ -26,7 +26,7 @@ $(info TEXINPUTS = $(TEXINPUTS))
 include pgfplots.makefile
 
 TeX-programming-notes.pdf: revisionfile FORCE
-	mkdir -p gnuplot
+	mkdir -p gnuplot figures/expensiveexamples
 	@$(TEXMFCNF_FOR_MEMLIMITS) && pdflatex $(@:.pdf=.tex)
 	@bibtex $(@:.pdf=) || exit 0
 	@makeindex $(@:.pdf=) || exit 0
@@ -34,7 +34,7 @@ TeX-programming-notes.pdf: revisionfile FORCE
 	@echo "$@ compiled successfully. You may need to re-run make several times to get all cross-references right."
 
 %.pdf: revisionfile FORCE
-	mkdir -p gnuplot
+	mkdir -p gnuplot figures/expensiveexamples
 	@$(TEXMFCNF_FOR_MEMLIMITS) && $(LATEX) $(@:.pdf=.tex)
 	@bibtex $(@:.pdf=) || exit 0
 	@makeindex $(@:.pdf=) || exit 0
@@ -59,6 +59,7 @@ html: FORCE
 pgfplots.pdf: $(ALL_FIGURES)
 
 pgfplots.makefile:
+	mkdir -p gnuplot figures/expensiveexamples
 	@$(TEXMFCNF_FOR_MEMLIMITS) && $(LATEX) pgfplots
 
 clean:

--- a/doc/latex/pgfplots/pgfplots-macros.tex
+++ b/doc/latex/pgfplots/pgfplots-macros.tex
@@ -123,7 +123,7 @@
 \def\pgfplotsmanualenableexternalizationofexpensive{%
     \pgfplotsmanual@enable@externalization@for@expensivetrue
     \tikzexternalize[
-        prefix=figures/expensiveexampleX,% the 'X' suffix is to avoid confusion in git: previous versions contained the pdfs in git
+        prefix=figures/expensiveexamples/,% the 'X' suffix is to avoid confusion in git: previous versions contained the pdfs in git
         figure name={},
         export=false, % needs to be activated for single pictures (i.e. expensive ones)
         mode=list and make,

--- a/doc/latex/pgfplots/pgfplotstodo.tex
+++ b/doc/latex/pgfplots/pgfplotstodo.tex
@@ -19,7 +19,7 @@
     prefix=bugtracker/minimal_,
 }
 
-\usepackage{luatodonotes}
+\usepackage{todonotes}
 \newcommand\todosp[2][]{%        % Stefan Pinnow
     \todo[
 %        disable,

--- a/scripts/pgfplots/Makefile.pgfplots_release_sourceforge
+++ b/scripts/pgfplots/Makefile.pgfplots_release_sourceforge
@@ -109,6 +109,8 @@ $(ZIP): FORCE
 		--exclude='Makefile.pgfplots_release_sourceforge' \
 		--exclude='acquirecopy.sh' \
 		--exclude='pgfplotsDEV_copy_files_from_pgf.sh' \
+		--exclude='ci' \
+		--exclude='tlpkg' \
 		-r $(DIR) /tmp
 	make -C /tmp/$(DIR)/doc/latex/pgfplots/gallery/ clean
 	rm -fr /tmp/$(DIR)/doc/latex/pgfplots/figures/generated

--- a/tex/generic/pgfplots/numtable/pgfplotstableshared.code.tex
+++ b/tex/generic/pgfplots/numtable/pgfplotstableshared.code.tex
@@ -1354,18 +1354,24 @@
 	\ifx\pgfplotstableread@tmp\pgfplotstableread@tmpb
 		\pgfplotstableread@skiplinetrue
 	\else
-		\let\pgfplotstableread@tmpb=$%
-		\let\pgfplotstableread@tmpb=\pgfplotstable@EOI%
+		\let\pgfplotstableread@tmpb=$%$
 		\ifx\pgfplotstableread@tmp\pgfplotstableread@tmpb
+			\pgfplots@warning{Ignoring flags line... not implemented}%
 			\pgfplotstableread@skiplinetrue
 			\pgfplotsscanlinecomplete% the line is empty; same as \par!
 		\else
-			\let\pgfplotstableread@tmpb=\par%
+			\let\pgfplotstableread@tmpb=\pgfplotstable@EOI%
 			\ifx\pgfplotstableread@tmp\pgfplotstableread@tmpb
 				\pgfplotstableread@skiplinetrue
-				\pgfplotsscanlinecomplete% the line is empty;
+				\pgfplotsscanlinecomplete% the line is empty; same as \par!
 			\else
-				\pgfplotstableread@checkspecial@line@default%
+				\let\pgfplotstableread@tmpb=\par%
+				\ifx\pgfplotstableread@tmp\pgfplotstableread@tmpb
+					\pgfplotstableread@skiplinetrue
+					\pgfplotsscanlinecomplete% the line is empty;
+				\else
+					\pgfplotstableread@checkspecial@line@default%
+				\fi
 			\fi
 		\fi
 	\fi


### PR DESCRIPTION
This enables building of the manual on Travis CI.  It takes quite a long time with build times averaging around half an hour.  I experimented with caching the `expensiveexample` pictures, but there are some unsatisfied dependencies which I was not yet able to resolve.  There are also some other to-dos left for the future:

- [x] Compiling the manual for every push
    - [x] with LuaTeX
    - [x] with pdfTeX
- [x] Caching of `expensiveexample` pictures
- [x] Recompile manual until convergence
- [x] Deploy development version and manual to `gh-pages` similar to [`update_tlcontrib.sh`](https://github.com/pgf-tikz/pgf/blob/master/ci/update_tlcontrib.sh) for PGF/TikZ