### PR TITLE
\usepgfplotslibrary used internal tikz macros

### DIFF
--- a/tex/generic/pgfplots/libs/pgfplotslibrary.code.tex
+++ b/tex/generic/pgfplots/libs/pgfplotslibrary.code.tex
@@ -41,15 +41,15 @@
 	\else
 		\pgfplotsiflibraryloaded{\pgf@temp}{}{%
 		  \expandafter\global\expandafter\let\csname pgfp@library@\pgf@temp @loaded\endcsname=\pgfutil@empty%
-		  \expandafter\edef\csname tikz@library@#1@atcode\endcsname{\the\catcode`\@}
-		  \expandafter\edef\csname tikz@library@#1@barcode\endcsname{\the\catcode`\|}
+		  \expandafter\edef\csname pgfplots@library@#1@atcode\endcsname{\the\catcode`\@}
+		  \expandafter\edef\csname pgfplots@library@#1@barcode\endcsname{\the\catcode`\|}
 		  \catcode`\@=11
 		  \catcode`\|=12
 		  \pgfplots@iffileexists{tikzlibrarypgfplots.\pgf@temp.code.tex}{%
 		  \input tikzlibrarypgfplots.\pgf@temp.code.tex}{%
 		  \input pgflibrarypgfplots.\pgf@temp.code.tex}%
-		  \catcode`\@=\csname tikz@library@#1@atcode\endcsname
-		  \catcode`\|=\csname tikz@library@#1@barcode\endcsname
+		  \catcode`\@=\csname pgfplots@library@#1@atcode\endcsname
+		  \catcode`\|=\csname pgfplots@library@#1@barcode\endcsname
 			\expandafter\ifx\csname pgfp@library@#1@loadoptions\endcsname\relax
 			\else
 				\expandafter\let\expandafter\pgfplots@glob@TMPa\csname pgfp@library@\pgf@temp @loadoptions\endcsname


### PR DESCRIPTION
Closes #216

`\usepgfplotslibrary` wrongly used an internal TikZ macro to keep track of catcodes.  The problem is that TikZ overwrites this macro again with the catcode it sees when the TikZ library is loaded.  So TikZ will see that @ has catcode 11 and set the macro to 11, overwriting the 12 that pgfplots set.  When pgfplots tries to restore the catcode, the macro will hold 11 instead of 12.

This problem only happens with `fillbetween` because there is a TikZ library with the same name.