### PR TITLE
Initialize \pgfplots@stacked@diff to 0

### DIFF
--- a/tex/generic/pgfplots/pgfplotsstackedplots.code.tex
+++ b/tex/generic/pgfplots/pgfplotsstackedplots.code.tex
@@ -686,3 +686,8 @@
 	\def\pgf@plotyzerolevelstreamend{%
 	}%
 }%
+
+% Initialize \pgfplots@stacked@diff to 0
+% Otherwise, if the first point in a plot is NaN \pgfplots@stacked@diff will be
+% undefined and an error is raised, see issue #219
+\def\pgfplots@stacked@diff{0}


### PR DESCRIPTION
Closes #219 

If the first point in a plot is NaN `\pgfplots@stacked@diff` will be undefined and an error is raised.