### PR TITLE
Fix wrong page link destinations

### DIFF
--- a/doc/latex/pgfplots/TeX-programming-notes.tex
+++ b/doc/latex/pgfplots/TeX-programming-notes.tex
@@ -60,9 +60,9 @@ At the time of this writing, this document is far from complete. Nevertheless, i
 
 \section{Programming in \TeX}
 \subsection{Variables in Registers}
+\label{sec:variables}
 \TeX\ provides several different variables and associated registers which can be manipulated freely.
 
-\label{sec:variables}
 \begin{command}{\count\meta{num}}
 	There are 256 Integer registers which provide 32 Bit Integer arithmetics. The registers can be used for example with |\count0=42 | or |\count7=\macro | where |\macro| expands to a number.
 

--- a/doc/latex/pgfplots/pgfmanual-en-macros.tex
+++ b/doc/latex/pgfplots/pgfmanual-en-macros.tex
@@ -22,11 +22,68 @@
 \definecolor{graphicbackground}{rgb}{0.96,0.96,0.8}
 \definecolor{codebackground}{rgb}{0.8,0.8,1}
 
-\newenvironment{pgfmanualentry}{\list{}{\leftmargin=2em\itemindent-\leftmargin\def\makelabel##1{\hss##1}}}{\endlist}
-\newcommand\pgfmanualentryheadline[1]{\itemsep=0pt\parskip=0pt\item\strut{#1}\par\topsep=0pt}
+\newenvironment{pgfmanualentry}{%
+  \pgfmanualresetlabel
+  \list{}{\leftmargin=2em\itemindent-\leftmargin\def\makelabel##1{\hss##1}}%
+}{\endlist}
+\newcounter{pgfmanualentry}
+\newcommand\pgfmanualentryheadline[1]{%
+  \itemsep=0pt\parskip=0pt\relax
+  {\raggedright\item\refstepcounter{pgfmanualentry}\pgfmanualstorelabel\strut{#1}\par}%
+  \topsep=0pt}
 \newcommand\pgfmanualbody{\parskip3pt}
 
+\makeatletter
+\newcounter{pgfmanual@label}
 
+\newcommand\pgfmanualresetlabel{%
+  \setcounter{pgfmanual@label}{0}}
+
+% Store 5-triple label info in \pgfmanual@label<num> for latter use.
+\newcommand\pgfmanualstorelabel{%
+  \stepcounter{pgfmanual@label}%
+  \label@hook % sanitize \@currentlabelname, come from nameref.sty
+  \expandafter\xdef\csname pgfmanual@label\number\c@pgfmanual@label\endcsname
+    {{\@currentlabel}{\thepage}{\@currentlabelname}{\@currentHref}{}}%
+}
+
+% Usage:
+%     \pgfmanuallabel{<label name>} % identical to \label{<label name>}
+%     \pgfmanuallabel[<index>]{<label name>}
+%
+% Currently the only usage is `\pgfmanuallabel[1]{...}`. This creates a label
+% as if it is inserted after first `\pgfmanualentryheadline`.
+% 
+% <index> starts from 1. Based on the \label (re)defined in nameref.sty.
+%
+\newcommand\pgfmanuallabel[2][-1]{%
+  \@bsphack
+  \begingroup
+    \def\label@name{#2}%
+    \ifnum#1=-1\relax
+      \label@hook
+      \protected@write\@auxout{}{%
+        \string\newlabel{#2}{%
+          {\@currentlabel}%
+          {\thepage}%
+          {\@currentlabelname}%
+          {\@currentHref}{}%
+        }%
+      }%
+    \else
+      % This is needed because \pgfmanual@label<num> is never cleared.
+      \ifnum#1<\numexpr\c@pgfmanual@label+1\relax
+        \protected@write\@auxout{}{%
+          \string\newlabel{#2}{\csname pgfmanual@label#1\endcsname}%
+        }%
+      \else
+        \PackageError{pgfmanual-macros}{Label index ``#2" output of range.}{}%
+      \fi
+    \fi
+  \endgroup
+  \@esphack
+}
+\makeatother
 
 \newenvironment{pgflayout}[1]{
   \begin{pgfmanualentry}

--- a/doc/latex/pgfplots/pgfmanual-en-macros.tex
+++ b/doc/latex/pgfplots/pgfmanual-en-macros.tex
@@ -29,60 +29,53 @@
 \newcounter{pgfmanualentry}
 \newcommand\pgfmanualentryheadline[1]{%
   \itemsep=0pt\parskip=0pt\relax
-  {\raggedright\item\refstepcounter{pgfmanualentry}\pgfmanualstorelabel\strut{#1}\par}%
+  {\raggedright\item\refstepcounter{pgfmanualentry}\pgfmanualstorelabel
+   \strut{#1}\par}%
   \topsep=0pt}
 \newcommand\pgfmanualbody{\parskip3pt}
 
 \makeatletter
-\newcounter{pgfmanual@label}
+\newif\if@pgfmanualfirstlabel
 
 \newcommand\pgfmanualresetlabel{%
-  \setcounter{pgfmanual@label}{0}}
+  \@pgfmanualfirstlabeltrue}
 
-% Store 5-triple label info in \pgfmanual@label<num> for latter use.
+% Store info of first label in \pgfmanual@labelinfo for latter use.
 \newcommand\pgfmanualstorelabel{%
-  \stepcounter{pgfmanual@label}%
-  \label@hook % sanitize \@currentlabelname, come from nameref.sty
-  \expandafter\xdef\csname pgfmanual@label\number\c@pgfmanual@label\endcsname
-    {{\@currentlabel}{\thepage}{\@currentlabelname}{\@currentHref}{}}%
+  \if@pgfmanualfirstlabel
+    \begingroup
+    \label@hook
+    \xdef\pgfmanual@labelinfo
+      {{\@currentlabel}{\thepage}{\@currentlabelname}{\@currentHref}{}}%
+    \endgroup
+    \global\@pgfmanualfirstlabelfalse
+  \fi
 }
 
-% Usage:
-%     \pgfmanuallabel{<label name>} % identical to \label{<label name>}
-%     \pgfmanuallabel[<index>]{<label name>}
-%
-% Currently the only usage is `\pgfmanuallabel[1]{...}`. This creates a label
-% as if it is inserted after first `\pgfmanualentryheadline`.
+% Used like a prifix of \label, \labelprefix makes the following 
+% \label use label info stored in \pgfmanual@labelinfo. Based on the 
 % 
-% <index> starts from 1. Based on the \label (re)defined in nameref.sty.
+% Usage:
+%     \labelprefix\label{<label name>}
+% Possible extension:
+%     \labelprefix[<offset>]\label{<label name>}
 %
-\newcommand\pgfmanuallabel[2][-1]{%
-  \@bsphack
-  \begingroup
-    \def\label@name{#2}%
-    \ifnum#1=-1\relax
-      \label@hook
+\newcommand\labelprefix[2]{%
+  \def\@pgfmanualtemp{#1}%
+  \ifx\@pgfmanualtemp\pgfmanual@labelcmd
+    \@bsphack
+    \begingroup
+      \def\label@name{#2}%
+      % \label@hook
       \protected@write\@auxout{}{%
-        \string\newlabel{#2}{%
-          {\@currentlabel}%
-          {\thepage}%
-          {\@currentlabelname}%
-          {\@currentHref}{}%
-        }%
-      }%
-    \else
-      % This is needed because \pgfmanual@label<num> is never cleared.
-      \ifnum#1<\numexpr\c@pgfmanual@label+1\relax
-        \protected@write\@auxout{}{%
-          \string\newlabel{#2}{\csname pgfmanual@label#1\endcsname}%
-        }%
-      \else
-        \PackageError{pgfmanual-macros}{Label index ``#2" output of range.}{}%
-      \fi
-    \fi
-  \endgroup
-  \@esphack
+        \string\newlabel{#2}{\pgfmanual@labelinfo}}%
+    \endgroup
+    \@esphack
+  \else
+    \PackageError{pgfmanual-macros}{\string\labelprefix should use as prefix of \string\label.}{}%
+  \fi
 }
+\def\pgfmanual@labelcmd{\label}
 \makeatother
 
 \newenvironment{pgflayout}[1]{

--- a/doc/latex/pgfplots/pgfplots.basic.reference.tex
+++ b/doc/latex/pgfplots/pgfplots.basic.reference.tex
@@ -1,6 +1,6 @@
 
 \chapter{Utilities and Basic Level Commands}
-\label{chap:pgfplots:lowlevel}
+\label{sec:pgfplots:lowlevel}
 
 This section documents commands which provide access to more basic elements of
 \PGFPlots{}. Most of them are closely related to the basic level of \pgfname{},

--- a/doc/latex/pgfplots/pgfplots.basic.reference.tex
+++ b/doc/latex/pgfplots/pgfplots.basic.reference.tex
@@ -1,6 +1,6 @@
 
 \chapter{Utilities and Basic Level Commands}
-\label{sec:pgfplots:lowlevel}
+\label{chap:pgfplots:lowlevel}
 
 This section documents commands which provide access to more basic elements of
 \PGFPlots{}. Most of them are closely related to the basic level of \pgfname{},

--- a/doc/latex/pgfplots/pgfplots.libs.dateplot.tex
+++ b/doc/latex/pgfplots/pgfplots.libs.dateplot.tex
@@ -6,6 +6,6 @@
     like |2008-01-01 11:35| as input coordinates in plots. The library converts
     dates to numbers and tick labels will be pretty-printed dates (or times).
 
-    This library is documented in Section~\ref{pgfplots:sec:date:coords} on
-    page~\pageref{pgfplots:sec:date:coords}.
+    This library is documented in Section~\ref{sec:pgfplots:date:coords} on
+    page~\pageref{sec:pgfplots:date:coords}.
 \end{pgfplotslibrary}

--- a/doc/latex/pgfplots/pgfplots.libs.fillbetween.tex
+++ b/doc/latex/pgfplots/pgfplots.libs.fillbetween.tex
@@ -72,7 +72,7 @@
     not overlap. This is done implicitly by \PGFPlots{}: as soon as \PGFPlots{}
     encounters a |fill between| plot, it will activate layered graphics. The
     filled path will be placed on layer \declareandlabel{pre main} which is
-    between the main layer and the background layer.\label{Layer!pre main}
+    between the main layer and the background layer.
 
     A |fill between| operation is just like a usual plot: it makes use of the
     |cycle list|, i.e.\@ it receives default plot styles. Our first example

--- a/doc/latex/pgfplots/pgfplots.libs.groupplots.tex
+++ b/doc/latex/pgfplots/pgfplots.libs.groupplots.tex
@@ -1,9 +1,9 @@
 
 \section{Grouping plots}
+\label{sec:group:plot}
 
 {
 \def\pgfplotsmanualcurlibrary{groupplots}
-\label{sec:group:plot}
 
 {\noindent {\emph{by Nick Papior Andersen}}}
 

--- a/doc/latex/pgfplots/pgfplots.libs.patchplots.tex
+++ b/doc/latex/pgfplots/pgfplots.libs.patchplots.tex
@@ -343,7 +343,7 @@ Note that both |rectangle| and |bilinear| also accept the standard matrix input
 Typically, \PGFPlots{} assumes that you want individually colored patch
 segments whenever you use one of the plot handlers  |mesh|, |surf|, or |patch|.
 The individual colors are determined by the current |colormap| and the value of
-|point meta| (compare section~\ref{pgfplots:point:meta}).
+|point meta| (compare section~\ref{sec:pgfplots:point:meta}).
 
 Technically, individually colored path segments are one unit. If you |fill|
 them, you fill only one segment. You cannot fill them against the axis. In

--- a/doc/latex/pgfplots/pgfplots.libs.ternary.tex
+++ b/doc/latex/pgfplots/pgfplots.libs.ternary.tex
@@ -262,6 +262,7 @@ appearance.
 \end{tikzpicture}
 \end{codeexample}
 
+\indent\refstepcounter{pgfmanualentry}\label{page:ternary:contour}
 Ternary plots can also use |contour prepared| to plot contour lines.
 The following example is a (crude) copy of an example of
 
@@ -294,7 +295,7 @@ The following example is a (crude) copy of an example of
 \end{tikzpicture}
 \end{codeexample}
 %
-\noindent \label{page:ternary:contour}The |contour prepared={labels over line}|
+\noindent The |contour prepared={labels over line}|
 installs the display style |contour/labels over line| and expects precomputed
 contour lines from the input stream. Here, the input stream is a table,
 consisting of the three relative components for Chromium, Iron and Nickel --

--- a/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
@@ -1965,7 +1965,7 @@ mandatory, the rest allows fine grained control over marker appearance options.
     special choice |f(x)| is the same as |y| for two dimensional plots and the
     same as |z| for three dimensional plots. The choice \declaretext{explicit}
     expects the scatter source data as additional coordinate from the
-    coordinate input streams (see Section~\ref{pgfplots:providing:input} for
+    coordinate input streams (see Section~\ref{sec:pgfplots:providing:input} for
     how to provide input meta data or below for some small examples). They will
     be treated as numerical data. The choice \declaretext{explicit symbolic}
     also expects scatter source data as additional meta information for each

--- a/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
@@ -2706,7 +2706,7 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
 
 
 \subsection{Interrupted Plots}
-\label{pgfplots:interrupt}
+\label{sec:pgfplots:interrupt}
     \index{Interrupted Plots}
 
 Sometimes it is desirable to draw parts of a single plot separately, without
@@ -2956,7 +2956,7 @@ other options about surface and mesh plots.
 \subsection{Polar Coordinates / Polar Axes}
 
 Polar coordinates can be provided in any kind of axis by means of
-|data cs=polar|, please refer to its reference documentation of
+|data cs=polar|, please refer to its reference documentation on
 page~\pageref{key:data:cs}.
 
 Polar axes are available by means of |\usepgfplotslibrary{polar}|; please refer
@@ -2974,6 +2974,6 @@ page~\pageref{sec:tieline}.
 
 Smith charts have a special coordinate system and a part of
 |\usepgfplotslibrary{smithchart}|; please refer to
-Section~\ref{sec:smithcharts}.
+Section~\ref{sec:smithcharts} on page~\pageref{sec:smithcharts}.
 
 }

--- a/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
@@ -2041,7 +2041,7 @@ mandatory, the rest allows fine grained control over marker appearance options.
     expected to depend on |mapped color|.
 
     The user interface for color maps is described in
-    Section~\ref{pgfplots:colormap}.
+    Section~\ref{sec:pgfplots:colormap}.
 
 \begin{codeexample}[]
 \begin{tikzpicture}

--- a/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
@@ -2274,6 +2274,7 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
     nodes near coords=\marg{content} (default \textbackslash pgfmathprintnumber\textbackslash pgfplotspointmeta),
     nodes near coords*=\marg{content} (default \textbackslash pgfmathprintnumber\textbackslash pgfplotspointmeta)%
 }
+\pgfmanuallabel[1]{pgfplots:example:pointmeta:nodesnearcoords}
     A |scatter| plot style which places text nodes near every coordinate.
 
 \begin{codeexample}[]
@@ -2301,7 +2302,6 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
     nodes:\footnote{In this case, the |\textbackslash pgfmathprintnumber| will
     be skipped automatically.}
     %
-    \label{pgfplots:example:pointmeta:nodesnearcoords}
 \begin{codeexample}[]
 \begin{tikzpicture}
 \begin{axis}[nodes near coords,enlargelimits=0.2]
@@ -2429,7 +2429,7 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
     coordinate style/.from=\marg{something expanding to options},
     coordinate style/.clear%
 }
-\label{key:coordinatestyle}
+\pgfmanuallabel[1]{key:coordinatestyle}
     These keys allow to define \meta{options} for \emph{selected} coordinates.
 
     The first key \declareandlabel{coordinate style/.condition} receives an
@@ -2576,6 +2576,7 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
     scatter/@pre marker code,
     scatter/@post marker code%
 }
+\pgfmanuallabel[1]{pgfplots:example:pointmeta:scatter}
     These two keys constitute the public interface which determines the marker
     appearance depending on scatter source coordinates.
 
@@ -2623,7 +2624,6 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
     example is also available as predefined style
     \texttt{scatter/classes}.}
     %
-    \label{pgfplots:example:pointmeta:scatter}
 \begin{codeexample}[]
 \begin{tikzpicture}
 % Low-Level scatter plot interface Example:

--- a/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.2dplots.tex
@@ -2274,7 +2274,7 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
     nodes near coords=\marg{content} (default \textbackslash pgfmathprintnumber\textbackslash pgfplotspointmeta),
     nodes near coords*=\marg{content} (default \textbackslash pgfmathprintnumber\textbackslash pgfplotspointmeta)%
 }
-\pgfmanuallabel[1]{pgfplots:example:pointmeta:nodesnearcoords}
+\labelprefix\label{pgfplots:example:pointmeta:nodesnearcoords}
     A |scatter| plot style which places text nodes near every coordinate.
 
 \begin{codeexample}[]
@@ -2429,7 +2429,7 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
     coordinate style/.from=\marg{something expanding to options},
     coordinate style/.clear%
 }
-\pgfmanuallabel[1]{key:coordinatestyle}
+\labelprefix\label{key:coordinatestyle}
     These keys allow to define \meta{options} for \emph{selected} coordinates.
 
     The first key \declareandlabel{coordinate style/.condition} receives an
@@ -2576,7 +2576,7 @@ First class is \ref{label:for:first:class}, second is \ref{label:for:second:clas
     scatter/@pre marker code,
     scatter/@post marker code%
 }
-\pgfmanuallabel[1]{pgfplots:example:pointmeta:scatter}
+\labelprefix\label{pgfplots:example:pointmeta:scatter}
     These two keys constitute the public interface which determines the marker
     appearance depending on scatter source coordinates.
 

--- a/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
@@ -359,7 +359,7 @@ Section~\ref{sec:pgfplots:export}.
 \end{pgfplotskey}
 
 \begin{addplot3operation}[]{\marg{math expression}}{}
-\label{cmd:addplot3:expr}
+\pgfmanuallabel[1]{cmd:addplot3:expr}
         \pgfmanualpdflabel{\textbackslash addplot3 expression}{}%
     Expression plotting also works in the same way as for two dimensional
     plots. Now, however, a two dimensional mesh is sampled instead of a single

--- a/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
@@ -58,7 +58,7 @@ Section~\ref{sec:pgfplots:export}.
     The \verbpdfref{\addplot3} command is the main interface for any three
     dimensional plot. It works in the same way as its two dimensional variant
     |\addplot| which has been described in all detail in
-    Section~\ref{cmd:pgfplots:addplot} on page~\pageref{cmd:pgfplots:addplot}.
+    Section~\ref{sec:addplot} on page~\pageref{sec:addplot}.
 
     The \verbpdfref{\addplot3} command accepts the same input methods as the
     |\addplot| variant, including expression plotting, coordinates, files and
@@ -4411,6 +4411,6 @@ the bar plot types like |ybar| for three dimensional axes, sorry.
 
 \subsection{Mesh/Surface Plots with Holes}
 
-Please refer to Section~\ref{pgfplots:interrupt} for interrupted plots.
+Please refer to Section~\ref{sec:pgfplots:interrupt} for interrupted plots.
 
 }

--- a/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
@@ -53,7 +53,7 @@ Section~\ref{sec:pgfplots:export}.
 
 
 \subsection{The \texttt{\textbackslash addplot3} Command: Three Dimensional Coordinate Input}
-\label{pgfplots:sec:threedim}
+\label{sec:pgfplots:sec:threedim}
 
 \begin{addplot3generic}
     The \verbpdfref{\addplot3} command is the main interface for any three
@@ -943,7 +943,7 @@ each input coordinate. The color for each box is determined by
     A surface plot visualizes a two dimensional, single patch using different
     fill colors for each patch segment. Each patch segment is a (pseudo)
     rectangle, that means input data is given in form of a data matrix as is
-    discussed in the introductory section~\ref{pgfplots:sec:threedim} about
+    discussed in the introductory section~\ref{sec:pgfplots:sec:threedim} about
     three dimensional coordinates.
 
 \pgfplotsexpensiveexample
@@ -959,7 +959,7 @@ each input coordinate. The color for each box is determined by
 \end{codeexample}
 
     The simplest way to generate surface plots is to use the plot expression
-    feature, but -- as discussed in Section~\ref{pgfplots:sec:threedim} --
+    feature, but -- as discussed in Section~\ref{sec:pgfplots:sec:threedim} --
     other input methods like \verbpdfref{\addplot3 table} or
     \verbpdfref{\addplot3 coordinates} are also possible.
 

--- a/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
@@ -11,7 +11,6 @@ coordinates and how to use the different plot types.
 
 
 \subsection{Before You Start With 3D}
-\label{pgfplots:3d:preliminary}
 
 Before we delve into the capabilities of \PGFPlots{} for three dimensional
 visualization, let me start with some preliminary remarks. The reason to use

--- a/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.3dplots.tex
@@ -358,7 +358,7 @@ Section~\ref{sec:pgfplots:export}.
 \end{pgfplotskey}
 
 \begin{addplot3operation}[]{\marg{math expression}}{}
-\pgfmanuallabel[1]{cmd:addplot3:expr}
+\labelprefix\label{cmd:addplot3:expr}
         \pgfmanualpdflabel{\textbackslash addplot3 expression}{}%
     Expression plotting also works in the same way as for two dimensional
     plots. Now, however, a two dimensional mesh is sampled instead of a single

--- a/doc/latex/pgfplots/pgfplots.reference.alignment.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.alignment.tex
@@ -1,6 +1,6 @@
 
 \section{Alignment Options}
-\label{pgfplots:sec:align}
+\label{sec:pgfplots:sec:align}
 
 \subsection{Basic Alignment}
 

--- a/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
@@ -269,7 +269,7 @@ plot coordinate).
             \]
         %
         with properly chosen integers $s_x, s_y, s_z \in \Z$ and shifts
-        $a_x,a_y, a_z\in \R$. Section~\ref{sec:disabledatascaling} contains a
+        $a_x,a_y, a_z\in \R$. Page~\pageref{pgfplots:disabledatascaling} contains a
         description of |disabledatascaling| and provides more details about
         the transformation.\index{Accuracy!Floating Point in \PGFPlots}
     \item Some of the coordinate input routines use the powerful
@@ -389,7 +389,7 @@ plot coordinate).
 
 
 \subsection{Coordinate Lists}
-\label{pgfplots:providing:input}
+\label{sec:pgfplots:providing:input}
 
 \begin{addplotoperation}[]{coordinates}{\marg{coordinate list}}
 \pgfmanuallabel[1]{pgfplots:addplot:coordinates}
@@ -482,7 +482,7 @@ data (if any) must be provided after the coordinates and after error bar bounds
 \end{codeexample}
 %
 Please refer to the documentation of |point meta| on
-page~\pageref{pgfplots:point:meta} for more information about per point meta
+page~\pageref{sec:pgfplots:point:meta} for more information about per point meta
 data.
 
 The coordinate stream can contain |empty line|s to tell \PGFPlots{} that the

--- a/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
@@ -392,7 +392,7 @@ plot coordinate).
 \label{sec:pgfplots:providing:input}
 
 \begin{addplotoperation}[]{coordinates}{\marg{coordinate list}}
-\pgfmanuallabel[1]{pgfplots:addplot:coordinates}
+\labelprefix\label{pgfplots:addplot:coordinates}
 
 The `|\addplot coordinates|' command is like that provided by \Tikz{} and reads
 its input data from a sequence of point coordinates, encapsulated in round
@@ -2498,7 +2498,7 @@ with \verbpdfref{\addplot3} |graphics|:
 \subsection{Reading Coordinates From Files}
 
 \begin{addplotoperation}[]{file}{\marg{name}}
-\pgfmanuallabel[1]{pgfplots:addplot:file}
+\labelprefix\label{pgfplots:addplot:file}
 
     \paragraph{Deprecation note:}
 

--- a/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
@@ -168,7 +168,6 @@ visualization and \verbpdfref{\addplot3} for three-dimensional visualization.
 
 \begin{command}{\addplot\oarg{options} \meta{input data}
     \meta{trailing path commands};}
-\label{cmd:pgfplots:addplot}
 
 This is the main plotting command, available within each axis environment. It
 can be used one or more times within an axis to add plots to the current axis.

--- a/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
@@ -392,7 +392,7 @@ plot coordinate).
 \label{pgfplots:providing:input}
 
 \begin{addplotoperation}[]{coordinates}{\marg{coordinate list}}
-\label{pgfplots:addplot:coordinates}
+\pgfmanuallabel[1]{pgfplots:addplot:coordinates}
 
 The `|\addplot coordinates|' command is like that provided by \Tikz{} and reads
 its input data from a sequence of point coordinates, encapsulated in round
@@ -2498,7 +2498,7 @@ with \verbpdfref{\addplot3} |graphics|:
 \subsection{Reading Coordinates From Files}
 
 \begin{addplotoperation}[]{file}{\marg{name}}
-\label{pgfplots:addplot:file}
+\pgfmanuallabel[1]{pgfplots:addplot:file}
 
     \paragraph{Deprecation note:}
 

--- a/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
@@ -1013,7 +1013,6 @@ Legends can be generated in two ways: the first is to use |\addlegendentry| or
 \end{command}
 
 \begin{command}{\legend\marg{list}}
-\label{sec:legenddef}
     You can use |\legend|\marg{list} to assign a complete legend.
     %
 \begin{codeexample}[code only]

--- a/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
@@ -94,7 +94,7 @@ use it explicitly.
 
     \begin{itemize}
         \item Each of the anchors described in
-            Section~\ref{pgfplots:sec:align} can be described by
+            Section~\ref{sec:pgfplots:sec:align} can be described by
             |axis description cs| as well.
         \item The |axis description cs| is independent of axis reversals or
             skewed axes. Only for the default configuration of boxed axes is
@@ -337,7 +337,7 @@ Besides the mentioned positioning methods, there is also the predefined node
 descriptions: At the time when axis descriptions are drawn, all anchors which
 refer to the axis origin (that means the ``real'' point $(0,0)$) or any of the
 axis corners can be referenced using |current axis.|\meta{anchor name}. Please
-see Section~\ref{pgfplots:sec:align}, Alignment, for further details.
+see Section~\ref{sec:pgfplots:sec:align}, Alignment, for further details.
 
 
 \subsection{Alignment of Axis Descriptions}
@@ -354,7 +354,7 @@ actually be moved to the desired position.
 |north|, |north east| etc. These names hold for any axis description as well
 (as axis descriptions are \Tikz{} nodes). Readers can learn details about this
 topic in the \Tikz{} manual~\cite{tikz} or some more advice in
-Section~\ref{pgfplots:sec:align}.
+Section~\ref{sec:pgfplots:sec:align}.
 
 When it comes to axis descriptions, \PGFPlots{} offers some specialized anchors
 and alignment methods which are described below.
@@ -2031,7 +2031,7 @@ computations, and place it absolutely such that it fits. Another is the
         \noindent will cause the legend to be positioned such that its |west|
         anchor is at |y=0pt|. The |baseline| option will align this point of
         the legend with the text baseline (please refer to the documentation
-        for |baseline| in Section~\ref{pgfplots:sec:align} for details).
+        for |baseline| in Section~\ref{sec:pgfplots:sec:align} for details).
     \end{stylekey}
 \end{pgfplotskey}
 
@@ -2806,7 +2806,7 @@ placed.
     %
     This can be used to embed a \PGFPlots{} path which needs an axis to a
     standard \tikzname{} picture. See also
-    Section~\ref{pgfplots:tikz:interoperability} for details how to synchronize
+    Section~\ref{sec:pgfplots:tikz:interoperability} for details how to synchronize
     the alignment between a \PGFPlots{} figure (which typically rescales its
     coordinates) to that of a standard |tikzpicture|.
 
@@ -2822,7 +2822,7 @@ placed.
 \label{pgfplots:colorbar}
 
 \PGFPlots{} supports mesh, surface and scatter plots which can use color maps.
-While color maps can be chosen as described in Section~\ref{pgfplots:colormap},
+While color maps can be chosen as described in Section~\ref{sec:pgfplots:colormap},
 they can be visualized using color bars.
 
 \begin{pgfplotskey}{colorbar=\mchoice{true,false} (initially false)}

--- a/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
@@ -2310,6 +2310,7 @@ change the appearance of the $x$- and $y$-axis lines.
 \end{pgfplotskeylist}
 
 \begin{pgfplotsxykey}{every inner \x\ axis line}
+\pgfmanuallabel[1]{pgfplots:page:axislines}
     A style key which can be redefined to customize the appearance of
     \emph{inner} axis lines. Inner axis lines are those drawn by the |middle|
     (or |center|) choice of |axis x line|, see above.
@@ -2352,7 +2353,6 @@ change the appearance of the $x$- and $y$-axis lines.
 \end{codeexample}
 \end{pgfplotsxykey}
 
-\label{pgfplots:page:axislines}
 \begin{pgfplotskey}{axis line style=\marg{key-value-list}}
     A command which appends \meta{key-value-list} to \emph{all} axis line
     appearance styles.
@@ -2717,7 +2717,7 @@ placed.
     \x tickmin=\marg{coord} (default axis limits),
     \x tickmax=\marg{coord} (default axis limits)%
 }
-\label{key:xytickminmax}
+\pgfmanuallabel[1]{key:xytickminmax}
     The options |xtickmin|, |xtickmax| and |ytickmin|, |ytickmax| allow to
     define the axis tick limits, i.e.\@ the axis values before respectively
     after no ticks will be placed. Everything outside of the axis tick limits

--- a/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
@@ -2309,7 +2309,7 @@ change the appearance of the $x$- and $y$-axis lines.
 \end{pgfplotskeylist}
 
 \begin{pgfplotsxykey}{every inner \x\ axis line}
-\pgfmanuallabel[1]{pgfplots:page:axislines}
+\labelprefix\label{pgfplots:page:axislines}
     A style key which can be redefined to customize the appearance of
     \emph{inner} axis lines. Inner axis lines are those drawn by the |middle|
     (or |center|) choice of |axis x line|, see above.
@@ -2716,7 +2716,7 @@ placed.
     \x tickmin=\marg{coord} (default axis limits),
     \x tickmax=\marg{coord} (default axis limits)%
 }
-\pgfmanuallabel[1]{key:xytickminmax}
+\labelprefix\label{key:xytickminmax}
     The options |xtickmin|, |xtickmax| and |ytickmin|, |ytickmax| allow to
     define the axis tick limits, i.e.\@ the axis values before respectively
     after no ticks will be placed. Everything outside of the axis tick limits

--- a/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axisdescription.tex
@@ -360,6 +360,7 @@ When it comes to axis descriptions, \PGFPlots{} offers some specialized anchors
 and alignment methods which are described below.
 
 \begin{anchorlist}{near xticklabel,near yticklabel,near zticklabel,near ticklabel}
+\labelprefix\label{key:near:ticklabel}
     These anchors can be used to align at the part of a node (for example, an
     axis description) which is \emph{nearest} to the tick labels of a
     particular axis (or nearest to the position where tick labels would have
@@ -368,7 +369,6 @@ and alignment methods which are described below.
     These anchors are used for axis labels, especially for three dimensional
     axes. Furthermore, they are used for every tick label.
 
-        \label{key:near:ticklabel}
     Maybe it is best to demonstrate it by example:
     %
 \begin{codeexample}[]
@@ -2654,6 +2654,7 @@ only the axis, without any plots:
 
 
 \subsection{Axis Discontinuities}
+\label{sec:axis:discontinuities}
 
 {\small \emph{An extension by Pascal Wolkotte}}
 \vspace{0.4cm}%

--- a/doc/latex/pgfplots/pgfplots.reference.bb-clip.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.bb-clip.tex
@@ -14,7 +14,7 @@ is subject of Section~\ref{sec:clipping}.
 
 Bounding box restrictions are a useful and often necessary tool if multiple
 pictures need to be aligned properly. Consequently, it is often applied
-together with the Alignments methods of Section~\ref{pgfplots:sec:align}.
+together with the Alignments methods of Section~\ref{sec:pgfplots:sec:align}.
 
 Bounding box restrictions can be achieved with several methods of \PGF{}:
 %

--- a/doc/latex/pgfplots/pgfplots.reference.bb-clip.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.bb-clip.tex
@@ -143,7 +143,6 @@ to use negative |\hspace| or |\vspace| commands (or options to
 \end{command}
 
 \begin{environment}{{pgfinterruptboundingbox}}
-\label{sec:bounding:box:example}
     \index{Bounding Box Control}
     \index{Bounding Box Control!pgfinterruptboundingbox}
 

--- a/doc/latex/pgfplots/pgfplots.reference.coordfiltering.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.coordfiltering.tex
@@ -353,7 +353,7 @@ transformations and their interaction.
     restrict \x\space to domain=\meta{min}:\meta{max},
     restrict \x\space to domain*=\meta{min}:\meta{max}%
 }
-\pgfmanuallabel[1]{key:restrict:x:to:domain}
+\labelprefix\label{key:restrict:x:to:domain}
     These keys append $x$ (or $y$ or $z$) coordinate filters to restrict the
     respective coordinate to a domain.
 

--- a/doc/latex/pgfplots/pgfplots.reference.coordfiltering.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.coordfiltering.tex
@@ -353,7 +353,7 @@ transformations and their interaction.
     restrict \x\space to domain=\meta{min}:\meta{max},
     restrict \x\space to domain*=\meta{min}:\meta{max}%
 }
-\label{key:restrict:x:to:domain}
+\pgfmanuallabel[1]{key:restrict:x:to:domain}
     These keys append $x$ (or $y$ or $z$) coordinate filters to restrict the
     respective coordinate to a domain.
 

--- a/doc/latex/pgfplots/pgfplots.reference.coordfiltering.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.coordfiltering.tex
@@ -9,7 +9,7 @@ application is to skip coordinates, i.e.\@ to install a filter which causes the
 coordinate to be skipped. This works by assigning special ``this coordinate
 does not exist'' values instead of the original values. Valid choices for
 ``this coordinate does not exist'' are defined using |unbounded coords| as
-described in Section~\ref{pgfplots:interrupt} about Interrupted Plots, namely
+described in Section~\ref{sec:pgfplots:interrupt} about Interrupted Plots, namely
 |empty line| or |unbounded coords|.
 
 See also Section~\ref{sec:transformation:interaction} for different types of
@@ -279,7 +279,7 @@ transformations and their interaction.
     an empty string (since empty strings will \emph{always} be discarded even
     in presence of |unbounded coords=jump|). Please see the reference
     documentation of |unbounded coords| and the example therein on
-    page~\pageref{pgfplots:interrupt} for details about coordinate filtering
+    page~\pageref{sec:pgfplots:interrupt} for details about coordinate filtering
     and three dimensional plots.
 \end{pgfplotsxycodekeylist}
 
@@ -449,4 +449,4 @@ transformations and their interaction.
 \end{pgfplotskey}
 
 You can find somewhat more on coordinate filtering in
-Section~\ref{pgfplots:interrupt}: ``Interrupted Plots''.
+Section~\ref{sec:pgfplots:interrupt}: ``Interrupted Plots''.

--- a/doc/latex/pgfplots/pgfplots.reference.gridoptions-axiscoordinates.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.gridoptions-axiscoordinates.tex
@@ -378,8 +378,8 @@ feature which is documented in its own section.
     feature.
 
     There is also a low-level interface to access the transformations and
-    coordinates, see Section~\ref{sec:pgfplots:lowlevel} on
-    page~\pageref{sec:pgfplots:lowlevel}.
+    coordinates, see Chapter~\ref{chap:pgfplots:lowlevel} on
+    page~\pageref{chap:pgfplots:lowlevel}.
 \end{coordinatesystem}
 
 \begin{predefinednode}{current plot begin}

--- a/doc/latex/pgfplots/pgfplots.reference.gridoptions-axiscoordinates.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.gridoptions-axiscoordinates.tex
@@ -378,8 +378,8 @@ feature which is documented in its own section.
     feature.
 
     There is also a low-level interface to access the transformations and
-    coordinates, see Chapter~\ref{chap:pgfplots:lowlevel} on
-    page~\pageref{chap:pgfplots:lowlevel}.
+    coordinates, see Section~\ref{sec:pgfplots:lowlevel} on
+    page~\pageref{sec:pgfplots:lowlevel}.
 \end{coordinatesystem}
 
 \begin{predefinednode}{current plot begin}

--- a/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
@@ -603,9 +603,9 @@ done using the following options of \Tikz{}.
 \end{tikzpicture}
 \end{codeexample}
 %
+\refstepcounter{pgfmanualentry}\label{page:plotcoords:src}%
 The preceding example defines data which is used a couple of times throughout
 this manual; it is referenced by
-\label{page:plotcoords:src}%
 \declareandlabel{\plotcoords}.%
 
 \begin{codeexample}[]

--- a/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
@@ -3625,7 +3625,7 @@ more complex ones.
 
 
 \section{Providing Color Data -- Point Meta}
-\label{pgfplots:point:meta}
+\label{sec:pgfplots:point:meta}
 
 \PGFPlots{} provides features which modify plots depending on a special
 coordinate, the ``point meta data''. For example, scatter plots may vary marker
@@ -3741,7 +3741,7 @@ manual.
 
             How point meta data is provided for |\addplot coordinates|,
             |\addplot table| and the other input methods is described in all detail
-            in Section~\ref{pgfplots:providing:input} -- but we provide small
+            in Section~\ref{sec:pgfplots:providing:input} -- but we provide small
             examples here to summarize the possibilities:
             %
 \begin{codeexample}[code only]
@@ -3835,7 +3835,7 @@ manual.
             are completely processed (transformations, logs) as mentioned
             above for the choice |x|. Furthermore, the \meta{expression} may
             depend on commands which are valid during |\addplot| like
-            |\plotnum| or |\coordindex| (see Section~\ref{pgfplots:misc} for
+            |\plotnum| or |\coordindex| (see Section~\ref{sec:pgfplots:misc} for
             details). If coordinates are provided using |\addplot table|, the
             macro |\thisrow|\marg{colname} is particularly useful as it
             allows to access the value of the provided \meta{colname} of the

--- a/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
@@ -797,6 +797,7 @@ The same can be achieved by means of the |xcolor| statement
 
 
 \subsection{Color Maps}
+\label{sec:pgfplots:colormap}
 
 A ``color map'' is a sequence of colors with smooth transitions between them.
 Color maps are often used to visualize ``color data'' in plots: in this case, a
@@ -806,7 +807,6 @@ plot has the position coordinates $(x,y)$ and some additional scalar value
 encountered value of |point meta| is mapped to the last color of a |colormap|,
 and interpolation happens in-between.
 
-\label{pgfplots:colormap}
 \begin{pgfplotskey}{colormap name=\marg{color map name} (initially hot)}
     Changes the current color map to the already defined map named \meta{color
     map name}. The predefined color maps are

--- a/doc/latex/pgfplots/pgfplots.reference.miscellaneous.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.miscellaneous.tex
@@ -1,6 +1,6 @@
 
 \section{Miscellaneous Options}
-\label{pgfplots:misc}
+\label{sec:pgfplots:misc}
 
 \begin{pgfplotskey}{disablelogfilter=\mchoice{true,false} (initially false, default true)}
     Disables numerical evaluation of $\log(x)$ in \TeX{}. If you specify this
@@ -18,7 +18,7 @@
 \end{pgfplotskey}
 
 \begin{pgfplotskey}{disabledatascaling=\mchoice{true,false} (initially false, default true)}
-\label{sec:disabledatascaling}
+\label{pgfplots:disabledatascaling}
         \index{Accuracy!Data Transformation}%
         \index{Errors!dimension too large}%
     Disables internal re-scaling of input data. Normally, every input data like

--- a/doc/latex/pgfplots/pgfplots.reference.numberformatting.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.numberformatting.tex
@@ -245,7 +245,6 @@ first to see if you need this section.
 \end{pgfplotskey}
 
 \begin{pgfplotskey}{log identify minor tick positions=\mchoice{true,false} (initially false)}
-\label{sec:identify:minor:log}
     Set this to |true| if you want to identify log plot tick labels at
     positions
         \[ i \cdot 10^j \]

--- a/doc/latex/pgfplots/pgfplots.reference.scaling.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.scaling.tex
@@ -378,7 +378,7 @@ All common options mentioned in the previous paragraphs are described here.
     Allows to reverse axis directions such that values are given in decreasing
     order.
 
-    This key is documented in all detail on page~\pageref{key:pgfplots:xydir}.
+    These keys are documented in all detail on page~\pageref{key:pgfplots:xydir}.
 \end{pgfplotsxykey}
 }
 

--- a/doc/latex/pgfplots/pgfplots.reference.specifyrange.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.specifyrange.tex
@@ -9,7 +9,7 @@
     min=\marg{coord},
     max=\marg{coord}%
 }
-\pgfmanuallabel[1]{page:access:limits}
+\labelprefix\label{page:access:limits}
     These options allow to define the axis limits, i.e.\@ the lower left and
     the upper right corner. Everything outside of the axis limits will be
     clipped away.
@@ -116,7 +116,7 @@
 \end{pgfplotsxykey}
 
 \begin{pgfplotsxykey}{\x\ dir=\mchoice{normal,reverse} (initially normal)}
-\pgfmanuallabel[1]{key:pgfplots:xydir}%
+\labelprefix\label{key:pgfplots:xydir}%
 \pgfkeys{/pdflinks/search key prefixes in/.add={/pgfplots/,}{}}
     Allows to reverse axis directions such that values are given in decreasing
     order.

--- a/doc/latex/pgfplots/pgfplots.reference.specifyrange.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.specifyrange.tex
@@ -9,6 +9,7 @@
     min=\marg{coord},
     max=\marg{coord}%
 }
+\pgfmanuallabel[1]{page:access:limits}
     These options allow to define the axis limits, i.e.\@ the lower left and
     the upper right corner. Everything outside of the axis limits will be
     clipped away.
@@ -99,7 +100,6 @@
 \end{tikzpicture}
 \end{codeexample}
     %
-        \label{page:access:limits}
     This access is possible inside of any axis description (like |xlabel|,
     |title|, |legend entries|, etc.) or any annotation (i.e.\@ inside of
     |\node|, |\draw| or |\path| and coordinates in |(|\meta{x}|,|\meta{y}|)|),
@@ -116,7 +116,7 @@
 \end{pgfplotsxykey}
 
 \begin{pgfplotsxykey}{\x\ dir=\mchoice{normal,reverse} (initially normal)}
-\label{key:pgfplots:xydir}%
+\pgfmanuallabel[1]{key:pgfplots:xydir}%
 \pgfkeys{/pdflinks/search key prefixes in/.add={/pgfplots/,}{}}
     Allows to reverse axis directions such that values are given in decreasing
     order.

--- a/doc/latex/pgfplots/pgfplots.reference.styleoptions.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.styleoptions.tex
@@ -242,7 +242,7 @@ own styles are defined easily.
     $y$/$z$ variants.
 \end{pgfplotsxykeylist}
 
-\noindent Please refer to Section~\ref{pgfplots:page:axislines} on
+\noindent Please refer to Section~\ref{sec:pgfplots:axislines} on
 page~\pageref{pgfplots:page:axislines} for details about styles for axis lines.
 
 \begin{stylekey}{/pgfplots/every 3d box foreground}

--- a/doc/latex/pgfplots/pgfplots.reference.symbolic-transformations.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.symbolic-transformations.tex
@@ -236,7 +236,7 @@ coordinate can then use any symbol provided in that dictionary.
 
 
 \subsection{Dates as Input Coordinates}
-\label{pgfplots:sec:date:coords}
+\label{sec:pgfplots:date:coords}
 
 {
 \def\pgfplotsmanualcurlibrary{dateplot}

--- a/doc/latex/pgfplots/pgfplots.reference.symbolic-transformations.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.symbolic-transformations.tex
@@ -1,6 +1,5 @@
 
 \section{Symbolic Coordinates and User Transformations}
-\label{pgfplots:sec:symbolic:coords}
 
 \PGFPlots{} supports user transformations which can be applied to input and
 output coordinates. Suppose the plot shall display days versus account

--- a/doc/latex/pgfplots/pgfplots.reference.tickoptions.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.tickoptions.tex
@@ -711,8 +711,8 @@ xticklabels={{0,5}, $e$}.
 \begin{pgfplotsxykeylist}{\x tickmin=\marg{coord}, \x tickmax=\marg{coord}}
     These keys can be used to modify minimum/maximum values before ticks are
     drawn. Because this applies to axis discontinuities, it is described on
-    page~\pageref{key:xytickminmax} in Section~\ref{key:xytickminmax}, ``Axis
-    Discontinuities"'.
+    page~\pageref{key:xytickminmax} in Section~\ref{sec:axis:discontinuities},
+    ``Axis Discontinuities".
 \end{pgfplotsxykeylist}
 
 

--- a/doc/latex/pgfplots/pgfplots.reference.tickoptions.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.tickoptions.tex
@@ -373,7 +373,7 @@
 \end{pgfplotsxykey}
 
 \begin{pgfplotsxykey}{\x ticklabels=\marg{label list}}
-\label{pgfplots:key:xticklabels}%
+\pgfmanuallabel[1]{pgfplots:key:xticklabels}%
 \index{Tick Labels!Texts as list: xticklabels}%
     Assigns a \emph{list} of tick \emph{labels} to each tick position. Tick
     \emph{positions} are assigned using the |xtick| and |ytick| options.
@@ -639,7 +639,7 @@ xticklabels={{0,5}, $e$}.
 \end{pgfplotsxykey}
 
 \begin{pgfplotsxykey}{\x\ tick label as interval=\mchoice{true,false} (initially false)}
-\label{key:pgfplots:ticklabelasinterval}
+\pgfmanuallabel[1]{key:pgfplots:ticklabelasinterval}
     Allows to treat tick labels as intervals; that means the tick positions
     denote the interval boundaries. If there are $n$ positions, $(n-1)$ tick
     labels will be generated, one for each interval.

--- a/doc/latex/pgfplots/pgfplots.reference.tickoptions.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.tickoptions.tex
@@ -373,7 +373,7 @@
 \end{pgfplotsxykey}
 
 \begin{pgfplotsxykey}{\x ticklabels=\marg{label list}}
-\pgfmanuallabel[1]{pgfplots:key:xticklabels}%
+\labelprefix\label{pgfplots:key:xticklabels}%
 \index{Tick Labels!Texts as list: xticklabels}%
     Assigns a \emph{list} of tick \emph{labels} to each tick position. Tick
     \emph{positions} are assigned using the |xtick| and |ytick| options.
@@ -639,7 +639,7 @@ xticklabels={{0,5}, $e$}.
 \end{pgfplotsxykey}
 
 \begin{pgfplotsxykey}{\x\ tick label as interval=\mchoice{true,false} (initially false)}
-\pgfmanuallabel[1]{key:pgfplots:ticklabelasinterval}
+\labelprefix\label{key:pgfplots:ticklabelasinterval}
     Allows to treat tick labels as intervals; that means the tick positions
     denote the interval boundaries. If there are $n$ positions, $(n-1)$ tick
     labels will be generated, one for each interval.

--- a/doc/latex/pgfplots/pgfplots.reference.tikzinteroperability.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.tikzinteroperability.tex
@@ -1,6 +1,6 @@
 
 \section{\tikzname{} Interoperability}
-\label{pgfplots:tikz:interoperability}
+\label{sec:pgfplots:tikz:interoperability}
 
 \PGFPlots{} uses \Tikz{}/\pgfname{} as its ``backend layer''. This implies that it
 inherits most of \Tikz's graphical features and adds a lot of own stuff on top
@@ -44,7 +44,7 @@ match coordinates with \Tikz{}, one needs the following aspects:
         to place the axis at the \Tikz{} position |(0,0)| whereas
         |anchor=origin| means that \PGFPlots{} will place its data origin
         $(0,0,0)$ at the place designated by |at| (see
-        Section~\ref{pgfplots:sec:align} for details).
+        Section~\ref{sec:pgfplots:sec:align} for details).
     \item Make sure that the \PGFPlots{} axis contains the data origin
         $(0,0,0)$ in the displayed data range (i.e.\@ configure |xmin|,
         |xmax|, |ymin|, and |ymax| appropriately).

--- a/doc/latex/pgfplots/pgfplots.reference.transformations.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.transformations.tex
@@ -1,6 +1,5 @@
 
 \section{Transforming Coordinate Systems}
-\label{key:data:cs}
 
 Usually, \PGFPlots{} works with Cartesian coordinates. However, one may want to
 provide coordinates in a different coordinate system.
@@ -9,6 +8,7 @@ In this case, the |data cs| key can be used to identify the input coordinate
 system:
 
 \begin{pgfplotskey}{data cs=\mchoice{cart,polar,polarrad} (initially cart)}
+    \label{key:data:cs}
     Defines the coordinate system (`cs') of the input coordinates. \PGFPlots{}
     will apply transformations if the argument does not match the expected
     coordinate system.

--- a/doc/latex/pgfplots/pgfplots.tutorial1.tex
+++ b/doc/latex/pgfplots/pgfplots.tutorial1.tex
@@ -443,7 +443,7 @@ alignment: for example if the two pictures should be centered horizontally or
 if they should be aligned with the left- and right end of the margins. The
 associated keys |\begin{tikzpicture}[trim axis left, trim axis right]| and
 |\centering| are beyond the scope of this tutorial, please refer to
-Section~\ref{pgfplots:sec:align} for details.
+Section~\ref{sec:pgfplots:sec:align} for details.
 
 
 \subsection{Satisfying Different Tastes}

--- a/doc/latex/pgfplots/pgfplots.tutorial3.tex
+++ b/doc/latex/pgfplots/pgfplots.tutorial3.tex
@@ -156,7 +156,7 @@ color in the |colormap|. All others are mapped to something in-between.
 
 More information about |colormap| and |point meta| can be found in
 Section~\ref{sec:colormap:input:format} and in
-Section~\ref{pgfplots:point:meta}.
+Section~\ref{sec:pgfplots:point:meta}.
 
 
 \subsection{Scatter Plot Use Case B}

--- a/doc/latex/pgfplots/pgfplots.tutorial3.tex
+++ b/doc/latex/pgfplots/pgfplots.tutorial3.tex
@@ -270,7 +270,7 @@ Furthermore, we introduced the concept of ``|point meta| data'': once as
 label.
 
 There is much more to say, especially about |point meta| which is introduced
-and explained in all depth in Section~\ref{pgfplots:point:meta}.
+and explained in all depth in Section~\ref{sec:pgfplots:point:meta}.
 
 There is also more to say about |scatter| plots, for example how to generate
 scatter plots with individually sized markers and/or colors (by relying on


### PR DESCRIPTION
This pr fixes wrong page link destinations created by `\pageref`.

### Notable changes
 - Applied same changes as did in https://github.com/pgf-tikz/pgf/pull/887. 
 - Provided `\labelprefix` used as prefix of `\label`. 
(The idea of a prefix of `\label` rather than a variant new label command has the advantage to not destroy label-ref analysis utility of some latex editors.)
 - Renamed label names. Use prefix `sec` if and only if it is a label of section title.

### New Semantics
Used at the beginning of a `pgfmanualentry`-based environment, now
 - `\label{...}` acts like it is inserted right after the _last_ `\pgfmanualentryheadline` of that env, and
 - `\labelprefix\label{...}` acts like the `\label` is inserted right after the _first_ `\pgfmanualentryheadline` of that env. 

### Test
I've manually checked every occurrence of word "page" in the locally built `pgfplots.pdf`.

### Discussion
Current implementation of `\labelprefix` scheme executes `\label@hook` at the time of storing label info, rather than creating new labels, and uses only one macro `\pgfmanual@labelinfo` to store 5-tuple label info. This may have compatibility problems with other label utilities provided by latex packages. A fully compatible implementation is to use five macros (four is enough since the last one is always empty) for storing label info.

Close #362