### PR TITLE
Skip over empty coordinates in linear regression

### DIFF
--- a/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
+++ b/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
@@ -2789,8 +2789,9 @@
 		\pgfplotslistpopfront\pgfplotstable@X\to\pgfplotstable@x
 		\pgfplotslistpopfront\pgfplotstable@Y\to\pgfplotstable@y
 		%
-		% if the y entry is empty, skip this point
-		\ifx\pgfplotstable@y\pgfutil@empty
+		% if either the x or y entry is empty, skip this point
+		\ifx\pgfplotstable@x\pgfutil@empty
+		\else\ifx\pgfplotstable@y\pgfutil@empty
 		\else
 			\pgfplotstableparsex{\pgfplotstable@x}%
 			\let\pgfplotstable@x=\pgfmathresult
@@ -2834,7 +2835,7 @@
 			\let\pgfplots@table@accum=\pgfmathresult
 			\pgfmathfloatadd@{\pgfplotstable@Sxy}{\pgfplots@table@accum}%
 			\let\pgfplotstable@Sxy=\pgfmathresult
-		\fi
+		\fi\fi
 	\pgfutil@repeat
 	%
 	\pgfmathparse{\pgfplotstable@S * \pgfplotstable@Sxx - \pgfplotstable@Sx *\pgfplotstable@Sx}%

--- a/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
+++ b/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
@@ -2789,48 +2789,52 @@
 		\pgfplotslistpopfront\pgfplotstable@X\to\pgfplotstable@x
 		\pgfplotslistpopfront\pgfplotstable@Y\to\pgfplotstable@y
 		%
-		\pgfplotstableparsex{\pgfplotstable@x}%
-		\let\pgfplotstable@x=\pgfmathresult
-		\expandafter\pgfplotslistpushback\pgfmathresult\to\pgfplotstable@Xparsed
-		\pgfplotstableparsey{\pgfplotstable@y}%
-		\let\pgfplotstable@y=\pgfmathresult
-		%
-		\pgfplotslistcheckempty\pgfplotstable@VARIANCE
-		\ifpgfplotslistempty
-			\pgfmathfloatcreate{1}{1.0}{0}%
-			\let\pgfplotstable@invsqr=\pgfmathresult
+		% if the y entry is empty, skip this point
+		\ifx\pgfplotstable@y\pgfutil@empty
 		\else
-			\pgfplotslistpopfront\pgfplotstable@VARIANCE\to\pgfplotstable@variance
-			\pgfmathfloatparsenumber{\pgfplotstable@variance}%
-			\let\pgfplotstable@variance=\pgfmathresult
-			\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%
-			\let\pgfplotstable@sqr=\pgfmathresult
-			\pgfmathfloatreciprocal@{\pgfplotstable@sqr}%
-			\let\pgfplotstable@invsqr=\pgfmathresult
+			\pgfplotstableparsex{\pgfplotstable@x}%
+			\let\pgfplotstable@x=\pgfmathresult
+			\expandafter\pgfplotslistpushback\pgfmathresult\to\pgfplotstable@Xparsed
+			\pgfplotstableparsey{\pgfplotstable@y}%
+			\let\pgfplotstable@y=\pgfmathresult
+			%
+			\pgfplotslistcheckempty\pgfplotstable@VARIANCE
+			\ifpgfplotslistempty
+				\pgfmathfloatcreate{1}{1.0}{0}%
+				\let\pgfplotstable@invsqr=\pgfmathresult
+			\else
+				\pgfplotslistpopfront\pgfplotstable@VARIANCE\to\pgfplotstable@variance
+				\pgfmathfloatparsenumber{\pgfplotstable@variance}%
+				\let\pgfplotstable@variance=\pgfmathresult
+				\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%
+				\let\pgfplotstable@sqr=\pgfmathresult
+				\pgfmathfloatreciprocal@{\pgfplotstable@sqr}%
+				\let\pgfplotstable@invsqr=\pgfmathresult
+			\fi
+			%
+			\pgfmathfloatadd@{\pgfplotstable@S}{\pgfplotstable@invsqr}%
+			\let\pgfplotstable@S=\pgfmathresult
+			%
+			\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplotstable@invsqr}%
+			\let\pgfplots@table@accum=\pgfmathresult
+			\pgfmathfloatadd@{\pgfplotstable@Sx}{\pgfplots@table@accum}%
+			\let\pgfplotstable@Sx=\pgfmathresult
+			%
+			\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplots@table@accum}%
+			\let\pgfplots@table@accum=\pgfmathresult
+			\pgfmathfloatadd@{\pgfplotstable@Sxx}{\pgfplots@table@accum}%
+			\let\pgfplotstable@Sxx=\pgfmathresult
+			%
+			\pgfmathfloatmultiply@{\pgfplotstable@y}{\pgfplotstable@invsqr}%
+			\let\pgfplots@table@accum=\pgfmathresult
+			\pgfmathfloatadd@{\pgfplotstable@Sy}{\pgfplots@table@accum}%
+			\let\pgfplotstable@Sy=\pgfmathresult
+			%
+			\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplots@table@accum}%
+			\let\pgfplots@table@accum=\pgfmathresult
+			\pgfmathfloatadd@{\pgfplotstable@Sxy}{\pgfplots@table@accum}%
+			\let\pgfplotstable@Sxy=\pgfmathresult
 		\fi
-		%
-		\pgfmathfloatadd@{\pgfplotstable@S}{\pgfplotstable@invsqr}%
-		\let\pgfplotstable@S=\pgfmathresult
-		%
-		\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplotstable@invsqr}%
-		\let\pgfplots@table@accum=\pgfmathresult
-		\pgfmathfloatadd@{\pgfplotstable@Sx}{\pgfplots@table@accum}%
-		\let\pgfplotstable@Sx=\pgfmathresult
-		%
-		\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplots@table@accum}%
-		\let\pgfplots@table@accum=\pgfmathresult
-		\pgfmathfloatadd@{\pgfplotstable@Sxx}{\pgfplots@table@accum}%
-		\let\pgfplotstable@Sxx=\pgfmathresult
-		%
-		\pgfmathfloatmultiply@{\pgfplotstable@y}{\pgfplotstable@invsqr}%
-		\let\pgfplots@table@accum=\pgfmathresult
-		\pgfmathfloatadd@{\pgfplotstable@Sy}{\pgfplots@table@accum}%
-		\let\pgfplotstable@Sy=\pgfmathresult
-		%
-		\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplots@table@accum}%
-		\let\pgfplots@table@accum=\pgfmathresult
-		\pgfmathfloatadd@{\pgfplotstable@Sxy}{\pgfplots@table@accum}%
-		\let\pgfplotstable@Sxy=\pgfmathresult
 	\pgfutil@repeat
 	%
 	\pgfmathparse{\pgfplotstable@S * \pgfplotstable@Sxx - \pgfplotstable@Sx *\pgfplotstable@Sx}%


### PR DESCRIPTION
Fixes #384

Should we be using `\pgfplots@PREPARE@COORD@STREAM` instead?  Possibly
we should be checking the coordinate filter, perhaps with some version
of `\ifpgfplotsaxisparsecoordinateok` and possibly emit some sort of
warning after checking `\ifpgfplots@warn@for@filter@discards`?  In any
case, I think the current version is strictly better.

Note that I have just added an `\ifx` check and indented the code, and haven't actually changed the code itself inside the `\ifx`.  

If someone lets me know how to add tests, I can add the test case from #384.

Edit: Also if I should update some changelog or something, let me know.