### PR TITLE
Fix log-mode linear regression w/ implicit weights

### DIFF
--- a/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
+++ b/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
@@ -2798,16 +2798,28 @@
 		\pgfplotslistcheckempty\pgfplotstable@VARIANCE
 		\ifpgfplotslistempty
 			\pgfmathfloatcreate{1}{1.0}{0}%
-			\let\pgfplotstable@invsqr=\pgfmathresult
+			\let\pgfplotstable@variance=\pgfmathresult
 		\else
 			\pgfplotslistpopfront\pgfplotstable@VARIANCE\to\pgfplotstable@variance
 			\pgfmathfloatparsenumber{\pgfplotstable@variance}%
 			\let\pgfplotstable@variance=\pgfmathresult
-			\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%
-			\let\pgfplotstable@sqr=\pgfmathresult
-			\pgfmathfloatreciprocal@{\pgfplotstable@sqr}%
-			\let\pgfplotstable@invsqr=\pgfmathresult
 		\fi
+		% if we're in y log mode, then instead of y +- dy, we have log_b(y +- dy)
+		% which Taylor expands to log_b(y) +- dy/(y ln(b)) + O(dy^2)
+		\ifx\pgfplotstableparseylogbase\pgfutil@empty
+		\else
+			\pgfplotstableparseyinv@{\pgfplotstable@y}% y
+			\let\pgfplotstable@tmp=\pgfmathresult
+			\pgfmathfloatmultiply@{\pgfplotstable@tmp}{\pgfplotstableparseylogofbasefloat}% y * ln(b)
+			\let\pgfplotstable@ylnb=\pgfmathresult
+			\pgfmathfloatdivide@{\pgfplotstable@variance}{\pgfplotstable@ylnb}% dy / (y * ln(b))
+			\let\pgfplotstable@variance=\pgfmathresult
+		\fi
+		%
+		\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%
+		\let\pgfplotstable@sqr=\pgfmathresult
+		\pgfmathfloatreciprocal@{\pgfplotstable@sqr}%
+		\let\pgfplotstable@invsqr=\pgfmathresult
 		%
 		\pgfmathfloatadd@{\pgfplotstable@S}{\pgfplotstable@invsqr}%
 		\let\pgfplotstable@S=\pgfmathresult

--- a/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
+++ b/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
@@ -2804,8 +2804,22 @@
 			\pgfmathfloatparsenumber{\pgfplotstable@variance}%
 			\let\pgfplotstable@variance=\pgfmathresult
 		\fi
+		%
 		% if we're in y log mode, then instead of y +- dy, we have log_b(y +- dy)
 		% which Taylor expands to log_b(y) +- dy/(y ln(b)) + O(dy^2)
+		% However, this might introduce a division-by-zero in the exceptional case
+		% where b=1 or log_b(0) = -infinity, so instead of computing 1/(dy/(y ln b))^2
+		% we will compute (y ln b)^2*1/dy^2.  Note that we don't factor out the ^2
+		% because floating point operations don't commute and the historical behavior
+		% was to compute 1/dy^2.
+		%
+		\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%
+		\let\pgfplotstable@sqr=\pgfmathresult
+		\pgfmathfloatreciprocal@{\pgfplotstable@sqr}%
+		\let\pgfplotstable@invsqr=\pgfmathresult
+		% N.B. at this point, \pgfplotstable@invsqr, \pgfplotstable@sqr, and \pgfplotstable@variance are
+		% all missing log-scaling.  We update \pgfplotstable@invsqr now, but leave \pgfplotstable@sqr
+		% and \pgfplotstable@variance alone because they are not used below this point.
 		\ifx\pgfplotstableparseylogbase\pgfutil@empty
 		\else
 			% However, before compat 1.18, this was not the behavior, so we recreate the
@@ -2816,15 +2830,14 @@
 				\let\pgfplotstable@tmp=\pgfmathresult
 				\pgfmathfloatmultiply@{\pgfplotstable@tmp}{\pgfplotstableparseylogofbasefloat}% y * ln(b)
 				\let\pgfplotstable@ylnb=\pgfmathresult
-				\pgfmathfloatdivide@{\pgfplotstable@variance}{\pgfplotstable@ylnb}% dy / (y * ln(b))
-				\let\pgfplotstable@variance=\pgfmathresult
+				\pgfmathfloatmultiply@{\pgfplotstable@ylnb}{\pgfplotstable@ylnb}% (y * ln(b))^2
+				\let\pgfplotstable@ylnbsqr=\pgfmathresult
+				% since \pgfplotstable@invsqr is used, but \pgfplotstable@sqr and \pgfplotstable@variance are not
+				% we only need to update \pgfplotstable@invsqr
+				\pgfmathfloatmultiply@{\pgfplotstable@invsqr}{\pgfplotstable@ylnbsqr}% (y * ln(b))^2 / dy^2
+				\let\pgfplotstable@invsqr=\pgfmathresult
 			\fi
 		\fi
-		%
-		\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%
-		\let\pgfplotstable@sqr=\pgfmathresult
-		\pgfmathfloatreciprocal@{\pgfplotstable@sqr}%
-		\let\pgfplotstable@invsqr=\pgfmathresult
 		%
 		\pgfmathfloatadd@{\pgfplotstable@S}{\pgfplotstable@invsqr}%
 		\let\pgfplotstable@S=\pgfmathresult

--- a/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
+++ b/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
@@ -2808,12 +2808,17 @@
 		% which Taylor expands to log_b(y) +- dy/(y ln(b)) + O(dy^2)
 		\ifx\pgfplotstableparseylogbase\pgfutil@empty
 		\else
-			\pgfplotstableparseyinv@{\pgfplotstable@y}% y
-			\let\pgfplotstable@tmp=\pgfmathresult
-			\pgfmathfloatmultiply@{\pgfplotstable@tmp}{\pgfplotstableparseylogofbasefloat}% y * ln(b)
-			\let\pgfplotstable@ylnb=\pgfmathresult
-			\pgfmathfloatdivide@{\pgfplotstable@variance}{\pgfplotstable@ylnb}% dy / (y * ln(b))
-			\let\pgfplotstable@variance=\pgfmathresult
+			% However, before compat 1.18, this was not the behavior, so we recreate the
+			% old behavior in compatibility versions.
+			\ifpgfplots@deprecated@dontlogscalevariance
+			\else
+				\pgfplotstableparseyinv@{\pgfplotstable@y}% y
+				\let\pgfplotstable@tmp=\pgfmathresult
+				\pgfmathfloatmultiply@{\pgfplotstable@tmp}{\pgfplotstableparseylogofbasefloat}% y * ln(b)
+				\let\pgfplotstable@ylnb=\pgfmathresult
+				\pgfmathfloatdivide@{\pgfplotstable@variance}{\pgfplotstable@ylnb}% dy / (y * ln(b))
+				\let\pgfplotstable@variance=\pgfmathresult
+			\fi
 		\fi
 		%
 		\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%

--- a/tex/generic/pgfplots/pgfplots.code.tex
+++ b/tex/generic/pgfplots/pgfplots.code.tex
@@ -129,6 +129,8 @@
 \newif\ifpgfplots@curplot@isirrelevant
 \newif\ifpgfplots@colorbar
 \newif\ifpgfplots@deprecated@anchors
+\newif\ifpgfplots@deprecated@dontlogscalevariance
+\pgfplots@deprecated@dontlogscalevariancefalse
 \newif\ifpgfplots@translategnuplot
 \pgfplots@translategnuplottrue
 \let\pgfnodepartimagebox=\pgfnodeparttextbox
@@ -4320,6 +4322,27 @@
 	/pgfplots/compat/anchors/1.17/.style= 	{/pgfplots/compat/anchors/1.13},%
 	/pgfplots/compat/anchors/default/.style={/pgfplots/compat/anchors/1.3},%
 	%
+	/pgfplots/compat/dontlogscalevariance/.is choice,
+	/pgfplots/compat/dontlogscalevariance/pre 1.3/.code=	{\pgfplots@deprecated@dontlogscalevariancetrue},
+	/pgfplots/compat/dontlogscalevariance/1.3/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.4/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.5/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.5.1/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.6/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.7/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.8/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.9/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.10/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.11/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.12/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.13/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.14/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.15/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.16/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.17/.style= 	{/pgfplots/compat/dontlogscalevariance/pre 1.3},
+	/pgfplots/compat/dontlogscalevariance/1.18/.code=	{\pgfplots@deprecated@dontlogscalevariancefalse},
+	/pgfplots/compat/dontlogscalevariance/default/.style=	{/pgfplots/compat/dontlogscalevariance/1.18},%
+	%
 	/pgfplots/compat/empty line/.is choice,
 	/pgfplots/compat/empty line/pre 1.3/.code={\pgfplots@emptyline@compattrue},% FIXME: WAS \global
 	/pgfplots/compat/empty line/1.3/.style= {/pgfplots/compat/empty line/pre 1.3},%
@@ -4692,6 +4715,7 @@
 		\pgfplotsutilforeachcommasep{%
 			/pgfplots/compat/current,%
 			/pgfplots/compat/anchors,%
+			/pgfplots/compat/dontlogscalevariance,%
 			/pgfplots/compat/labels,%
 			/pgfplots/compat/empty line,%
 			/pgfplots/compat/scaling,%
@@ -4730,6 +4754,7 @@
 					% the same choices due to this construction:
 					/pgfplots/compat/current=#1,% remember the value
 					/pgfplots/compat/anchors=#1,%
+					/pgfplots/compat/dontlogscalevariance=#1,%
 					/pgfplots/compat/labels=#1,%
 					/pgfplots/compat/empty line=#1,%
 					/pgfplots/compat/scaling=#1,%
@@ -11571,7 +11596,7 @@
 			\pgfplotsutil@directlua{%
 				pgfplots.gca = pgfplots.Axis.new();
 				pgfplots.gca.is3d = \pgfplots@boolval{pgfplots@threedim};
-				pgfplots.gca.clipLimits = { 
+				pgfplots.gca.clipLimits = {
 					\pgfplots@boolval{pgfplots@clip@limits@x},
 					\pgfplots@boolval{pgfplots@clip@limits@y},
 					\pgfplots@boolval{pgfplots@clip@limits@z} };


### PR DESCRIPTION
Previously the weights were assumed to be log(y) ± Δy,whereas
they should actually be log(y ± Δy).  We now compute the weights
correctly (to first order series approximation).

Fixes #352