### PR TITLE
fix loglog matrix/image plot

### DIFF
--- a/tex/generic/pgfplots/pgfplotsmeshplotimage.code.tex
+++ b/tex/generic/pgfplots/pgfplotsmeshplotimage.code.tex
@@ -107,6 +107,9 @@
 			\ifx\pgfplotsplothandlermesh@image@lastA\pgfutil@empty
 			\else
 				\pgfplotscoordmath{x}{parse}{\pgfplotsplothandlermesh@image@lastA - 0.5*(\pgfplotsplothandlermesh@cur - \pgfplotsplothandlermesh@image@lastA)}%
+				\ifpgfplots@xislinear\else
+					\pgfplotscoordmath{x}{parsenumber}{\pgfmathresult}%
+				\fi
 				\let\pgfplots@current@point@xh=\pgfmathresult
 				\pgfplotsplothandlermesh@image@updatelimits@AB\pgfplots@current@point@xh\pgfplotsplothandlermesh@cur@B\pgfplots@current@point@z
 				%
@@ -121,11 +124,17 @@
 			\ifx\pgfplotsplothandlermesh@image@lastB\pgfutil@empty
 			\else
 				\pgfplotscoordmath{y}{parse}{\pgfplotsplothandlermesh@image@lastB - 0.5*(\pgfplotsplothandlermesh@cur@B - \pgfplotsplothandlermesh@image@lastB)}%
+				\ifpgfplots@yislinear\else
+					\pgfplotscoordmath{y}{parsenumber}{\pgfmathresult}%
+				\fi
 				\let\pgfplots@current@point@yh=\pgfmathresult
 				\pgfplotsplothandlermesh@image@updatelimits@AB\pgfplotsplothandlermesh@cur\pgfplots@current@point@yh\pgfplots@current@point@z
 				%
 				%
 				\pgfplotscoordmath{y}{parse}{\pgfplotsplothandlermesh@cur@B + 0.5*(\pgfplotsplothandlermesh@cur@B - \pgfplotsplothandlermesh@image@lastB)}%
+				\ifpgfplots@yislinear\else
+					\pgfplotscoordmath{y}{parsenumber}{\pgfmathresult}%
+				\fi
 				\let\pgfplots@current@point@yh=\pgfmathresult
 				\pgfplotsplothandlermesh@image@updatelimits@AB\pgfplotsplothandlermesh@cur\pgfplots@current@point@yh\pgfplots@current@point@z
 				%
@@ -146,6 +155,9 @@
 		\else
 			\expandafter\let\expandafter\pgfplotsplothandlermesh@cur@B\csname pgfplots@current@point@\pgfplotsplothandlermesh@image@B@dir\endcsname
 			\pgfplotscoordmath{x}{parse}{\pgfplotsplothandlermesh@image@lastA + 0.5*(\pgfplotsplothandlermesh@image@lastA - \pgfplotsplothandlermesh@image@lastlastA)}%
+			\ifpgfplots@xislinear\else
+				\pgfplotscoordmath{x}{parsenumber}{\pgfmathresult}%
+			\fi
 			\let\pgfplots@current@point@xh=\pgfmathresult
 			\pgfplotsplothandlermesh@image@updatelimits@AB\pgfplots@current@point@xh\pgfplotsplothandlermesh@cur@B\pgfplots@current@point@z
 		\fi

--- a/tex/generic/pgfplots/pgfplotsmeshplotimage.code.tex
+++ b/tex/generic/pgfplots/pgfplotsmeshplotimage.code.tex
@@ -106,10 +106,10 @@
 		\else
 			\ifx\pgfplotsplothandlermesh@image@lastA\pgfutil@empty
 			\else
-				\pgfplotscoordmath{x}{parse}{\pgfplotsplothandlermesh@image@lastA - 0.5*(\pgfplotsplothandlermesh@cur - \pgfplotsplothandlermesh@image@lastA)}%
-				\ifpgfplots@xislinear\else
-					\pgfplotscoordmath{x}{parsenumber}{\pgfmathresult}%
-				\fi
+				\pgfplotscoordmath{\pgfplotsplothandlermesh@image@A@dir}{parse}{\pgfplotsplothandlermesh@image@lastA - 0.5*(\pgfplotsplothandlermesh@cur - \pgfplotsplothandlermesh@image@lastA)}%
+				\pgfplots@if{pgfplots@\pgfplotsplothandlermesh@image@A@dir islinear}{}{%
+					\pgfplotscoordmath{\pgfplotsplothandlermesh@image@A@dir}{parsenumber}{\pgfmathresult}%
+				}
 				\let\pgfplots@current@point@xh=\pgfmathresult
 				\pgfplotsplothandlermesh@image@updatelimits@AB\pgfplots@current@point@xh\pgfplotsplothandlermesh@cur@B\pgfplots@current@point@z
 				%
@@ -123,18 +123,18 @@
 		\else
 			\ifx\pgfplotsplothandlermesh@image@lastB\pgfutil@empty
 			\else
-				\pgfplotscoordmath{y}{parse}{\pgfplotsplothandlermesh@image@lastB - 0.5*(\pgfplotsplothandlermesh@cur@B - \pgfplotsplothandlermesh@image@lastB)}%
-				\ifpgfplots@yislinear\else
-					\pgfplotscoordmath{y}{parsenumber}{\pgfmathresult}%
-				\fi
+				\pgfplotscoordmath{\pgfplotsplothandlermesh@image@B@dir}{parse}{\pgfplotsplothandlermesh@image@lastB - 0.5*(\pgfplotsplothandlermesh@cur@B - \pgfplotsplothandlermesh@image@lastB)}%
+				\pgfplots@if{pgfplots@\pgfplotsplothandlermesh@image@B@dir islinear}{}{%
+					\pgfplotscoordmath{\pgfplotsplothandlermesh@image@B@dir}{parsenumber}{\pgfmathresult}%
+				}
 				\let\pgfplots@current@point@yh=\pgfmathresult
 				\pgfplotsplothandlermesh@image@updatelimits@AB\pgfplotsplothandlermesh@cur\pgfplots@current@point@yh\pgfplots@current@point@z
 				%
 				%
-				\pgfplotscoordmath{y}{parse}{\pgfplotsplothandlermesh@cur@B + 0.5*(\pgfplotsplothandlermesh@cur@B - \pgfplotsplothandlermesh@image@lastB)}%
-				\ifpgfplots@yislinear\else
-					\pgfplotscoordmath{y}{parsenumber}{\pgfmathresult}%
-				\fi
+				\pgfplotscoordmath{\pgfplotsplothandlermesh@image@B@dir}{parse}{\pgfplotsplothandlermesh@cur@B + 0.5*(\pgfplotsplothandlermesh@cur@B - \pgfplotsplothandlermesh@image@lastB)}%
+				\pgfplots@if{pgfplots@\pgfplotsplothandlermesh@image@B@dir islinear}{}{%
+					\pgfplotscoordmath{\pgfplotsplothandlermesh@image@B@dir}{parsenumber}{\pgfmathresult}%
+				}
 				\let\pgfplots@current@point@yh=\pgfmathresult
 				\pgfplotsplothandlermesh@image@updatelimits@AB\pgfplotsplothandlermesh@cur\pgfplots@current@point@yh\pgfplots@current@point@z
 				%
@@ -154,10 +154,10 @@
 		\ifx\pgfplotsplothandlermesh@image@lastA\pgfutil@empty
 		\else
 			\expandafter\let\expandafter\pgfplotsplothandlermesh@cur@B\csname pgfplots@current@point@\pgfplotsplothandlermesh@image@B@dir\endcsname
-			\pgfplotscoordmath{x}{parse}{\pgfplotsplothandlermesh@image@lastA + 0.5*(\pgfplotsplothandlermesh@image@lastA - \pgfplotsplothandlermesh@image@lastlastA)}%
-			\ifpgfplots@xislinear\else
-				\pgfplotscoordmath{x}{parsenumber}{\pgfmathresult}%
-			\fi
+			\pgfplotscoordmath{\pgfplotsplothandlermesh@image@A@dir}{parse}{\pgfplotsplothandlermesh@image@lastA + 0.5*(\pgfplotsplothandlermesh@image@lastA - \pgfplotsplothandlermesh@image@lastlastA)}%
+			\pgfplots@if{pgfplots@\pgfplotsplothandlermesh@image@A@dir islinear}{}{%
+				\pgfplotscoordmath{\pgfplotsplothandlermesh@image@A@dir}{parsenumber}{\pgfmathresult}%
+			}
 			\let\pgfplots@current@point@xh=\pgfmathresult
 			\pgfplotsplothandlermesh@image@updatelimits@AB\pgfplots@current@point@xh\pgfplotsplothandlermesh@cur@B\pgfplots@current@point@z
 		\fi


### PR DESCRIPTION
This fixes #390.

The problem seems to be that the plot handler (in `\pgfplotsaxisupdatelimitsforcoordinate`) expects fixed point numbers if we're in log mode but the mesh@image plot handler calls it with floating point numbers.

My quick fix is to convert the numbers if we're in log mode.
Unfortunately I don't understand the codebase enough to know whether this is the right fix in the right place or it should be tackled elsewhere, but it works.

Before:
![loglogmatrixplot](https://user-images.githubusercontent.com/1215851/109939465-5f12aa80-7cd1-11eb-812c-cef68c8a77d9.png)

After:
![loglogmatrixplot_fixed](https://user-images.githubusercontent.com/1215851/109939482-646ff500-7cd1-11eb-9286-57e84e4d59ab.png)
