### PR TITLE
Set up GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,130 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        engine: [lualatex]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/texlive
+          ~/.texlive
+          /tmp/tlpkg
+          doc/latex/pgfplots/figures/expensiveexamples
+          doc/latex/pgfplots/gnuplot
+        key: texlive
+
+    - name: Set up TeX Live environment
+      uses: pgf-tikz/actions/install-tl@master
+      with:
+        packages:
+          accsupp
+          acrotex
+          amsfonts
+          amsmath
+          atbegshi
+          atveryend
+          auxhook
+          bibtex
+          bitset
+          booktabs
+          colortbl
+          conv-xkv
+          ec
+          epstopdf-pkg
+          etex-pkg
+          etexcmds
+          etoolbox
+          eurosym
+          geometry
+          german
+          graphics
+          hycolor
+          hyperref
+          ifoddpage
+          iftex
+          infwarerr
+          intcalc
+          kvdefinekeys
+          kvoptions
+          kvsetkeys
+          l3kernel
+          l3packages
+          latex
+          latex-bin
+          letltxmacro
+          listings
+          ltxcmds
+          luacode
+          luainputenc
+          luatex
+          luatex85
+          luatexbase
+          luatodonotes
+          makeindex
+          metafont
+          mfware
+          multido
+          multirow
+          pdfescape
+          pdflscape
+          pdftexcmds
+          pgf
+          pgfplots
+          preview
+          psnfss
+          soul
+          soulpos
+          standalone
+          todonotes
+          tools
+          units
+          url
+          varwidth
+          vmargin
+          xcolor
+          xkeyval
+          xstring
+          zref
+
+    - name: 'Install system dependencies'
+      run: |
+        sudo apt-get update -yy
+        sudo apt-get install -yy gnuplot
+
+    - name: 'Install pgfplots'
+      run: |
+        tlmgr init-usertree --usertree $PWD
+        echo "TEXMFHOME=$PWD" >> $GITHUB_ENV
+
+    - name: Generate the revision file
+      run: |
+        bash scripts/pgfplots/pgfplotsrevisionfile.sh
+        cat tex/generic/pgfplots/pgfplots.revision.tex
+        echo "GIT_TAG=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+
+    - name: Build the manual
+      run: |
+        cd doc/latex/pgfplots
+        while : ; do
+          make -j $(nproc) LATEX="${{ matrix.engine }} -shell-escape -halt-on-error -interaction=nonstopmode"
+          grep -q -E "(There were undefined references|Rerun to get (cross-references|the bars) right)" *.log || break
+          [ "$(( thisrun=$(( thisrun + 1 )) ))" -lt 5 ] || { echo "Reruns exceeded"; exit 1; }
+        done
+        cd -
+
+    - name: Build package
+      run: |
+        make -C .. -f pgfplots/scripts/pgfplots/Makefile.pgfplots_release_sourceforge

--- a/doc/latex/pgfplots/Makefile
+++ b/doc/latex/pgfplots/Makefile
@@ -26,7 +26,7 @@ $(info TEXINPUTS = $(TEXINPUTS))
 include pgfplots.makefile
 
 TeX-programming-notes.pdf: revisionfile FORCE
-	mkdir -p gnuplot
+	mkdir -p gnuplot figures/expensiveexamples
 	@$(TEXMFCNF_FOR_MEMLIMITS) && pdflatex $(@:.pdf=.tex)
 	@bibtex $(@:.pdf=) || exit 0
 	@makeindex $(@:.pdf=) || exit 0
@@ -34,7 +34,7 @@ TeX-programming-notes.pdf: revisionfile FORCE
 	@echo "$@ compiled successfully. You may need to re-run make several times to get all cross-references right."
 
 %.pdf: revisionfile FORCE
-	mkdir -p gnuplot
+	mkdir -p gnuplot figures/expensiveexamples
 	@$(TEXMFCNF_FOR_MEMLIMITS) && $(LATEX) $(@:.pdf=.tex)
 	@bibtex $(@:.pdf=) || exit 0
 	@makeindex $(@:.pdf=) || exit 0
@@ -59,6 +59,7 @@ html: FORCE
 pgfplots.pdf: $(ALL_FIGURES)
 
 pgfplots.makefile:
+	mkdir -p gnuplot figures/expensiveexamples
 	@$(TEXMFCNF_FOR_MEMLIMITS) && $(LATEX) pgfplots
 
 clean:

--- a/doc/latex/pgfplots/pgfplots-macros.tex
+++ b/doc/latex/pgfplots/pgfplots-macros.tex
@@ -124,7 +124,7 @@
 \def\pgfplotsmanualenableexternalizationofexpensive{%
     \pgfplotsmanual@enable@externalization@for@expensivetrue
     \tikzexternalize[
-        prefix=figures/expensiveexampleX,% the 'X' suffix is to avoid confusion in git: previous versions contained the pdfs in git
+        prefix=figures/expensiveexamples/,% the 'X' suffix is to avoid confusion in git: previous versions contained the pdfs in git
         figure name={},
         export=false, % needs to be activated for single pictures (i.e. expensive ones)
         mode=list and make,


### PR DESCRIPTION
Supersedes https://github.com/pgf-tikz/pgfplots/pull/347

This enables building of the manual on GitHub Actions.  It is slightly faster than Travis CI and does not require a third-party service.  PGF is already using GitHub Actions and I have prepared some reusable blocks that also come in handy when building pgfplots.

Here is a list of things already done:

- [x] Compiling the manual for every push with LuaTeX
- [x] Caching of `expensiveexample` pictures
- [x] Recompile manual until convergence

Possible to do in this PR, but needs feedback:

- [ ] Deploy manual as artefact and/or to GitHub pages
- [ ] Deploy tagged releases to GitHub Releases
- [ ] Deploy tagged releases to CTAN

To do for another PR in the future:

- [ ] Compiling the manual for every push with pdfTeX (completely broken since `contour lua`)
- [ ] Build the gallery
- [ ] Build the Lua tests
- [ ] Build the regression tests
- [ ] Build the unit tests