### PR TITLE
delete a duplicate of \pgfplotsarraypushbackglobal

### DIFF
--- a/tex/generic/pgfplots/liststructure/pgfplotsarray.code.tex
+++ b/tex/generic/pgfplots/liststructure/pgfplotsarray.code.tex
@@ -188,13 +188,6 @@
 	\pgfplotsarray@@\xdef{#2@size}{\the\c@pgfplotsarray@tmp}%
 }
 
-\long\def\pgfplotsarraypushbackglobal#1\to#2{%
-	\pgfplotsarraysize{#2}\to\c@pgfplotsarray@tmp
-	\pgfplotsarray@@\gdef{#2@\the\c@pgfplotsarray@tmp}{#1}%
-	\advance\c@pgfplotsarray@tmp by1
-	\pgfplotsarray@@\xdef{#2@size}{\the\c@pgfplotsarray@tmp}%
-}
-
 % Counts the number of elements in array #1, storing it into the count
 % register #2.
 % Example:


### PR DESCRIPTION
There are two identical definition of `\pgfplotsarraypushbackglobal` in `pgfplotsarray.code.tex`. This PR deletes one of them.
https://github.com/pgf-tikz/pgfplots/blob/3bc2f42258fbfac9fe50b2978459da7e76fc046c/tex/generic/pgfplots/liststructure/pgfplotsarray.code.tex#L184-L196

The duplicate was introduced in commit https://github.com/pgf-tikz/pgfplots/commit/511630af4aefbc4b4e127462e618829816acb144# 