### PR TITLE
Skip non-finite values in Linear Regressions

### DIFF
--- a/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
+++ b/tex/generic/pgfplots/numtable/pgfplotstable.code.tex
@@ -2793,83 +2793,86 @@
 		\pgfplotslistpopfront\pgfplotstable@X\to\pgfplotstable@x
 		\pgfplotslistpopfront\pgfplotstable@Y\to\pgfplotstable@y
 		%
-		% if either the x or y entry is empty, skip this point
-		\ifx\pgfplotstable@x\pgfutil@empty
-		\else\ifx\pgfplotstable@y\pgfutil@empty
-		\else
-			\pgfplotstableparsex{\pgfplotstable@x}%
-			\let\pgfplotstable@x=\pgfmathresult
-			\expandafter\pgfplotslistpushback\pgfmathresult\to\pgfplotstable@Xparsed
-			\pgfplotstableparsey{\pgfplotstable@y}%
-			\let\pgfplotstable@y=\pgfmathresult
-			%
-			\pgfplotslistcheckempty\pgfplotstable@VARIANCE
-			\ifpgfplotslistempty
-				\pgfmathfloatcreate{1}{1.0}{0}%
-				\let\pgfplotstable@variance=\pgfmathresult
-			\else
-				\pgfplotslistpopfront\pgfplotstable@VARIANCE\to\pgfplotstable@variance
-				\pgfmathfloatparsenumber{\pgfplotstable@variance}%
-				\let\pgfplotstable@variance=\pgfmathresult
-			\fi
-			%
-			% if we're in y log mode, then instead of y +- dy, we have log_b(y +- dy)
-			% which Taylor expands to log_b(y) +- dy/(y ln(b)) + O(dy^2)
-			% However, this might introduce a division-by-zero in the exceptional case
-			% where b=1 or log_b(0) = -infinity, so instead of computing 1/(dy/(y ln b))^2
-			% we will compute (y ln b)^2*1/dy^2.  Note that we don't factor out the ^2
-			% because floating point operations don't commute and the historical behavior
-			% was to compute 1/dy^2.
-			%
-			\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%
-			\let\pgfplotstable@sqr=\pgfmathresult
-			\pgfmathfloatreciprocal@{\pgfplotstable@sqr}%
-			\let\pgfplotstable@invsqr=\pgfmathresult
-			\ifx\pgfplotstableparseylogbase\pgfutil@empty
-			\else
-				\if m\pgfplotstable@regression@variance@format
-					% variance format=log
+		% if either the x or y entry is non-finite, skip this point
+		\pgfplotstableread@if@finite\pgfplotstable@x{%
+			\pgfplotstableread@if@finite\pgfplotstable@y{%
+				\pgfplotstableparsex{\pgfplotstable@x}%
+				\let\pgfplotstable@x=\pgfmathresult
+				\expandafter\pgfplotslistpushback\pgfmathresult\to\pgfplotstable@Xparsed
+				\pgfplotstableparsey{\pgfplotstable@y}%
+				\let\pgfplotstable@y=\pgfmathresult
+				%
+				\pgfplotslistcheckempty\pgfplotstable@VARIANCE
+				\ifpgfplotslistempty
+					\pgfmathfloatcreate{1}{1.0}{0}%
+					\let\pgfplotstable@variance=\pgfmathresult
 				\else
-					% variance format=linear
-					% N.B. at this point, \pgfplotstable@invsqr, \pgfplotstable@sqr, and \pgfplotstable@variance are
-					% all missing log-scaling.  We update \pgfplotstable@invsqr now, but leave \pgfplotstable@sqr
-					% and \pgfplotstable@variance alone because they are not used below this point.
-					\pgfplotstableparseyinv@{\pgfplotstable@y}% y
-					\let\pgfplotstable@tmp=\pgfmathresult
-					\pgfmathfloatmultiply@{\pgfplotstable@tmp}{\pgfplotstableparseylogofbasefloat}% y * ln(b)
-					\let\pgfplotstable@ylnb=\pgfmathresult
-					\pgfmathfloatmultiply@{\pgfplotstable@ylnb}{\pgfplotstable@ylnb}% (y * ln(b))^2
-					\let\pgfplotstable@ylnbsqr=\pgfmathresult
-					% since \pgfplotstable@invsqr is used, but \pgfplotstable@sqr and \pgfplotstable@variance are not
-					% we only need to update \pgfplotstable@invsqr
-					\pgfmathfloatmultiply@{\pgfplotstable@invsqr}{\pgfplotstable@ylnbsqr}% (y * ln(b))^2 / dy^2
-					\let\pgfplotstable@invsqr=\pgfmathresult
+					\pgfplotslistpopfront\pgfplotstable@VARIANCE\to\pgfplotstable@variance
+					\pgfmathfloatparsenumber{\pgfplotstable@variance}%
+					\let\pgfplotstable@variance=\pgfmathresult
 				\fi
-			\fi
-			%
-			\pgfmathfloatadd@{\pgfplotstable@S}{\pgfplotstable@invsqr}%
-			\let\pgfplotstable@S=\pgfmathresult
-			%
-			\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplotstable@invsqr}%
-			\let\pgfplots@table@accum=\pgfmathresult
-			\pgfmathfloatadd@{\pgfplotstable@Sx}{\pgfplots@table@accum}%
-			\let\pgfplotstable@Sx=\pgfmathresult
-			%
-			\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplots@table@accum}%
-			\let\pgfplots@table@accum=\pgfmathresult
-			\pgfmathfloatadd@{\pgfplotstable@Sxx}{\pgfplots@table@accum}%
-			\let\pgfplotstable@Sxx=\pgfmathresult
-			%
-			\pgfmathfloatmultiply@{\pgfplotstable@y}{\pgfplotstable@invsqr}%
-			\let\pgfplots@table@accum=\pgfmathresult
-			\pgfmathfloatadd@{\pgfplotstable@Sy}{\pgfplots@table@accum}%
-			\let\pgfplotstable@Sy=\pgfmathresult
-			%
-			\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplots@table@accum}%
-			\let\pgfplots@table@accum=\pgfmathresult
-			\pgfmathfloatadd@{\pgfplotstable@Sxy}{\pgfplots@table@accum}%
-			\let\pgfplotstable@Sxy=\pgfmathresult
-		\fi\fi
+				%
+				% if we're in y log mode, then instead of y +- dy, we have log_b(y +- dy)
+				% which Taylor expands to log_b(y) +- dy/(y ln(b)) + O(dy^2)
+				% However, this might introduce a division-by-zero in the exceptional case
+				% where b=1 or log_b(0) = -infinity, so instead of computing 1/(dy/(y ln b))^2
+				% we will compute (y ln b)^2*1/dy^2.  Note that we don't factor out the ^2
+				% because floating point operations don't commute and the historical behavior
+				% was to compute 1/dy^2.
+				%
+				\pgfmathfloatmultiply@{\pgfplotstable@variance}{\pgfplotstable@variance}%
+				\let\pgfplotstable@sqr=\pgfmathresult
+				\pgfmathfloatreciprocal@{\pgfplotstable@sqr}%
+				\let\pgfplotstable@invsqr=\pgfmathresult
+				\ifx\pgfplotstableparseylogbase\pgfutil@empty
+				\else
+					\if m\pgfplotstable@regression@variance@format
+						% variance format=log
+					\else
+						% variance format=linear
+						% N.B. at this point, \pgfplotstable@invsqr, \pgfplotstable@sqr, and \pgfplotstable@variance are
+						% all missing log-scaling.  We update \pgfplotstable@invsqr now, but leave \pgfplotstable@sqr
+						% and \pgfplotstable@variance alone because they are not used below this point.
+						\pgfplotstableparseyinv@{\pgfplotstable@y}% y
+						\let\pgfplotstable@tmp=\pgfmathresult
+						\pgfmathfloatmultiply@{\pgfplotstable@tmp}{\pgfplotstableparseylogofbasefloat}% y * ln(b)
+						\let\pgfplotstable@ylnb=\pgfmathresult
+						\pgfmathfloatmultiply@{\pgfplotstable@ylnb}{\pgfplotstable@ylnb}% (y * ln(b))^2
+						\let\pgfplotstable@ylnbsqr=\pgfmathresult
+						% since \pgfplotstable@invsqr is used, but \pgfplotstable@sqr and \pgfplotstable@variance are not
+						% we only need to update \pgfplotstable@invsqr
+						\pgfmathfloatmultiply@{\pgfplotstable@invsqr}{\pgfplotstable@ylnbsqr}% (y * ln(b))^2 / dy^2
+						\let\pgfplotstable@invsqr=\pgfmathresult
+					\fi
+				\fi
+				%
+				\pgfmathfloatadd@{\pgfplotstable@S}{\pgfplotstable@invsqr}%
+				\let\pgfplotstable@S=\pgfmathresult
+				%
+				\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplotstable@invsqr}%
+				\let\pgfplots@table@accum=\pgfmathresult
+				\pgfmathfloatadd@{\pgfplotstable@Sx}{\pgfplots@table@accum}%
+				\let\pgfplotstable@Sx=\pgfmathresult
+				%
+				\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplots@table@accum}%
+				\let\pgfplots@table@accum=\pgfmathresult
+				\pgfmathfloatadd@{\pgfplotstable@Sxx}{\pgfplots@table@accum}%
+				\let\pgfplotstable@Sxx=\pgfmathresult
+				%
+				\pgfmathfloatmultiply@{\pgfplotstable@y}{\pgfplotstable@invsqr}%
+				\let\pgfplots@table@accum=\pgfmathresult
+				\pgfmathfloatadd@{\pgfplotstable@Sy}{\pgfplots@table@accum}%
+				\let\pgfplotstable@Sy=\pgfmathresult
+				%
+				\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplots@table@accum}%
+				\let\pgfplots@table@accum=\pgfmathresult
+				\pgfmathfloatadd@{\pgfplotstable@Sxy}{\pgfplots@table@accum}%
+				\let\pgfplotstable@Sxy=\pgfmathresult
+			}{%
+				\pgfplotslistpushback\to\pgfplotstable@Xparsed%
+		}}{%
+			\pgfplotslistpushback\to\pgfplotstable@Xparsed%
+		}%
 	\pgfutil@repeat
 	%
 	\pgfmathparse{\pgfplotstable@S * \pgfplotstable@Sxx - \pgfplotstable@Sx *\pgfplotstable@Sx}%
@@ -2883,15 +2886,19 @@
 	%
 	\pgfplotslistnewempty\pgfplotstable@RESULT
 	\pgfplotslistforeachungrouped\pgfplotstable@Xparsed\as\pgfplotstable@x{%
-		\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplotstable@a}%
-		\let\pgfplotstable@tmp=\pgfmathresult
-		\pgfmathfloatadd@{\pgfplotstable@tmp}{\pgfplotstable@b}%
-		\ifx\pgfplotstableparseylogbase\pgfutil@empty
-		\else
-			\pgfplotstableparseyinv@{\pgfmathresult}%
-		\fi
-		\pgfmathfloattosci{\pgfmathresult}%
-		\expandafter\pgfplotslistpushback\pgfmathresult\to\pgfplotstable@RESULT
+		\pgfplotstableread@if@finite\pgfplotstable@x{%
+			\pgfmathfloatmultiply@{\pgfplotstable@x}{\pgfplotstable@a}%
+			\let\pgfplotstable@tmp=\pgfmathresult
+			\pgfmathfloatadd@{\pgfplotstable@tmp}{\pgfplotstable@b}%
+			\ifx\pgfplotstableparseylogbase\pgfutil@empty
+			\else
+				\pgfplotstableparseyinv@{\pgfmathresult}%
+			\fi
+			\pgfmathfloattosci{\pgfmathresult}%
+			\expandafter\pgfplotslistpushback\pgfmathresult\to\pgfplotstable@RESULT
+		}{%
+			\pgfplotslistpushback\to\pgfplotstable@RESULT%
+		}%
 	}%
 	\pgfmathfloattosci\pgfplotstable@a
 	\let\pgfplotstable@a=\pgfmathresult

--- a/tex/generic/pgfplots/numtable/pgfplotstableshared.code.tex
+++ b/tex/generic/pgfplots/numtable/pgfplotstableshared.code.tex
@@ -1817,7 +1817,25 @@
 	\pgfplotstableread@countadvance\pgfplotstableread@curcol
 }
 
-
+\long\def\pgfplotstableread@if@finite#1#2#3{%
+	\ifx#1\pgfutil@empty%
+		#3%
+	\else\ifx#1\pgfplotstableread@isnumber@nan%
+		#3%
+	\else\ifx#1\pgfplotstableread@isnumber@NaN%
+		#3%
+	\else\ifx#1\pgfplotstableread@isnumber@NAN%
+		#3%
+	\else\ifx#1\pgfplotstableread@isnumber@inf%
+		#3%
+	\else\ifx#1\pgfplotstableread@isnumber@Inf%
+		#3%
+	\else\ifx#1\pgfplotstableread@isnumber@INF%
+		#3%
+	\else%
+		#2%
+	\fi\fi\fi\fi\fi\fi\fi%
+}
 
 
 \long\def\pgfplotstableread@impl@countcols@and@identifynames@NEXT#1{%
@@ -1825,26 +1843,9 @@
 	\ifpgfplotstable@search@header
 		\ifpgfplotstableread@curline@contains@colnames
 		\else
-			\def\pgfplotstableread@CURTOK{#1}%
-			% can we safely use the \pgfmathfloatparsenumber here? I
-			% doubt it -- what if the header contains macros?
-			%
-			% there is no (simple) expandable "to lower case". check
-			% for the most common forms here.
-			\ifx\pgfplotstableread@CURTOK\pgfplotstableread@isnumber@nan
-			\else
-			\ifx\pgfplotstableread@CURTOK\pgfplotstableread@isnumber@NaN
-			\else
-			\ifx\pgfplotstableread@CURTOK\pgfplotstableread@isnumber@NAN
-			\else
-			\ifx\pgfplotstableread@CURTOK\pgfplotstableread@isnumber@inf
-			\else
-			\ifx\pgfplotstableread@CURTOK\pgfplotstableread@isnumber@Inf
-			\else
-			\ifx\pgfplotstableread@CURTOK\pgfplotstableread@isnumber@INF
-			\else
-				\pgfplotstableread@isnumber@ITERATE#1\pgfplotstable@EOI
-			\fi\fi\fi\fi\fi\fi
+			\pgfplotstableread@if@finite{#1}{%
+				\pgfplotstableread@isnumber@ITERATE#1\pgfplotstable@EOI%
+			}{}%
 %\ifpgfplotstableread@curline@contains@colnames\pgfplots@message{'#1' is a column name!}\else\pgfplots@message{'#1' is NO column name!}\fi
 		\fi
 	\fi


### PR DESCRIPTION
Currently, any NaNs in a table column will cause a linear regression to produce only NaNs. This commit makes `create col/linear regression` skip any non-finite (NaN, +Inf, -Inf) values when calculating regression coefficients.

This also fixes a small bug in 39ee730 where skipping an empty point doesn't also skip ahead the regression value.

I'm pretty unfamiliar with the PGF internals, so let me know if you need me to make any changes.

---

## Test Case

```latex
\documentclass{article}
\usepackage{pgfplots}
\pgfplotsset{compat=1.18}
\usepackage{pgfplotstable}
\begin{document}

\pgfplotstableread[col sep=comma]{
    a,b,c
    1,,2
    2,1,4
    3,2,nan
    4,3,8
}{\data}

\pgfplotstablecreatecol[linear regression={x=a, y=b}]{regressionb}{\data}
\pgfplotstablecreatecol[linear regression={x=a, y=c}]{regressionc}{\data}


\begin{tikzpicture}
  \begin{axis}
    \addplot[only marks] table [x=a, y=b] {\data};
    \addplot[no markers] table [x=a, y=regressionb] {\data};

    \addplot[only marks] table [x=a, y=c] {\data};
    \addplot[no markers] table [x=a, y=regressionc] {\data};
  \end{axis}
\end{tikzpicture}

\pgfplotstabletypeset\data

\end{document}
```

|Before|After|
|:-:|:-:|
|![before](https://user-images.githubusercontent.com/49086429/145662920-8935b025-d026-4726-84f8-2787ff4b0451.png)|![after](https://user-images.githubusercontent.com/49086429/145662927-56a747e1-ddc7-45f0-9ca2-cba197698ed2.png)|

