### PR TITLE
Fix typos

### DIFF
--- a/doc/latex/pgfplots/pgfplots.tutorial4.tex
+++ b/doc/latex/pgfplots/pgfplots.tutorial4.tex
@@ -91,7 +91,7 @@ how to visualize the input data. The key |mesh/ordering=y varies| tells
 \PGFPlots{} how to decode the input matrix. This is important; otherwise
 \PGFPlots{} would have chosen |x varies| which does not match our file.
 
-Note that we there is no need to configure either |mesh/rows=|\meta{N} or
+Note that there is no need to configure either |mesh/rows=|\meta{N} or
 |mesh/cols=|\meta{N} here because these parameters are automatically deduced
 from the scan line lengths marked by empty lines in our input file.
 

--- a/doc/latex/pgfplots/pgfplots.tutorial4.tex
+++ b/doc/latex/pgfplots/pgfplots.tutorial4.tex
@@ -329,10 +329,10 @@ Note that |contour lua| is different from almost all other plot handlers of
 
 |pdflatex |\meta{texfilename} .
 
-\noindent 
+\noindent
 The nonlinear algorithm to
 compute contour lines is currently unavailable in plain \TeX{} which is stressed
-by the name `|contour lua|'. 
+by the name `|contour lua|'.
 
 
 If you cannot use |lualatex| for some reason, you can replace |contour lua| by |contour gnuplot|, provided that you have the external program |gnuplot| installed on your system (see the reference for |contour gnuplot| for more details).

--- a/doc/latex/pgfplots/pgfplots.tutorial4.tex
+++ b/doc/latex/pgfplots/pgfplots.tutorial4.tex
@@ -141,7 +141,7 @@ configures it to be displayed horizontally. The labels are placed using
 functions. A colorbar uses the current |colormap| and adds axis descriptions to
 show how values are mapped to colors.
 
- The |shader=interp| key activates a smooth color interpolation.
+The |shader=interp| key activates a smooth color interpolation.
 
 
 \subsection{Adding Scattered Data on Top of the Surface}


### PR DESCRIPTION
The first commit removes a superfluous word. The last two remove some superfluous spaces.

Please cherry-pick, if you think think these commits are bad for later blaming.