### PR TITLE
`trig format value` is `rad` (and not `red`)

### DIFF
--- a/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.axis-addplot.tex
@@ -1261,7 +1261,7 @@ prefix can always be omitted when used in a \PGFPlots{} method.
     this feature is currently unavailable for |polaraxis| and |smithchart|.
 \end{pgfplotskey}
 
-\begin{key}{/pgf/trig format=\mchoice{deg,red} (initially deg)}
+\begin{key}{/pgf/trig format=\mchoice{deg,rad} (initially deg)}
     Allows to reconfigure the trigonometric format for \emph{all} user arguments.
 
     This affects \emph{all} user arguments including |view|, \tikzname{} polar


### PR DESCRIPTION
Fixes #418