### PR TITLE
Fix the phi(m) function.

### DIFF
--- a/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
@@ -3918,7 +3918,7 @@ manual.
     a function
         \[ \phi\colon [m_{\min},m_{\max}] \to [0,1000] \]
     with
-        \[ \phi(m) = \frac{1000(m - m_{\min})}{m_{\max} - m_{\min}} \]
+        \[ \phi(m) = \frac{m - m_{\min}}{m_{\max} - m_{\min}} \cdot 1000 \]
     such that $\phi(m_{\min}) = 0$ and $\phi(m_{\max})=1000$. The value $1000$
     is -- per convention -- the upper limit of all color maps. Now, if a
     coordinate (or edge/face) has the point meta data $m$, its color will be

--- a/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
@@ -3918,7 +3918,7 @@ manual.
     a function
         \[ \phi\colon [m_{\min},m_{\max}] \to [0,1000] \]
     with
-        \[ \phi(m) = \frac{m - m_{\min}} {1000} \]
+        \[ \phi(m) = \frac{1000(m - m_{\min})}{m_{\max} - m_{\min}} \]
     such that $\phi(m_{\min}) = 0$ and $\phi(m_{\max})=1000$. The value $1000$
     is -- per convention -- the upper limit of all color maps. Now, if a
     coordinate (or edge/face) has the point meta data $m$, its color will be


### PR DESCRIPTION
It seems to me that the following comment in pgfplotscolormap.code.tex

    % Step 1: perform lookup. Map #4 into the colormap's range
    % using the linear trafo
    % phi(#4) = ( #4 - #1 ) / (#2-#1) * colormaprange(#5).

is correct and the documentation is not.
