### PR TITLE
Missing minor ticks

### DIFF
--- a/tex/generic/pgfplots/pgfplotsticks.code.tex
+++ b/tex/generic/pgfplots/pgfplotsticks.code.tex
@@ -1038,7 +1038,7 @@
 					% SEE BELOW for the 'minor #1tick' feature -- it has a
 					% separate loop.
 					\foreach \pgfplots@i in {1,...,\pgfplots@minor@tick@num} {%
-						% XXX : bug 165 [minor ticks] minor tick drawn after the last xtick 
+						% XXX : bug 165 [minor ticks] minor tick drawn after the last xtick
 						% seems to be here. Does that harm?
 						\ifpgfplots@islinear
 							\pgfmathmultiply@{\pgfplots@i}{\pgfplots@minor@tick@dist}%
@@ -2309,7 +2309,10 @@
 	%
 	\if0\pgfplots@tick@returnval@ready
 		\xdef\pgfplots@glob@TMPb{\pgf@sys@tonumber{\H}}%
-		\advance\MAX by0.5\H % avoid rounding inaccuracies:
+    % No minor ticks will be drawn past the last tick, so we
+    % need to add one H to make sure it is past the axis limit.
+    % Add an extra H / 2 to avoid rounding inaccuracies.
+		\advance\MAX by1.5\H
 		\xdef\pgfplots@glob@TMPa{\pgf@sys@tonumber{\MIN},\pgf@sys@tonumber{\MINH},...,\pgf@sys@tonumber{\MAX}}%
 	\fi
 %\message{final H=\the\H; returning \pgfplots@glob@TMPa.}%

--- a/tex/generic/pgfplots/pgfplotsticks.code.tex
+++ b/tex/generic/pgfplots/pgfplotsticks.code.tex
@@ -1033,13 +1033,15 @@
 			\fi
 			% X-Axis ticks bottom and top
 			\ifpgfplots@needsminorloop
+				% Do not add minor ticks past the last xtick.
+				% When auto-generating tick positions, an extra tick past the axis
+				% limit is ensured by \pgfplots@assign@default@tick@foraxis@compute
+				% so that no minor ticks are omitted in that case.
 				\ifnum\pgfplots@ticknum=\c@pgfplots@ticknum@last\relax
 				\else
 					% SEE BELOW for the 'minor #1tick' feature -- it has a
 					% separate loop.
 					\foreach \pgfplots@i in {1,...,\pgfplots@minor@tick@num} {%
-						% XXX : bug 165 [minor ticks] minor tick drawn after the last xtick
-						% seems to be here. Does that harm?
 						\ifpgfplots@islinear
 							\pgfmathmultiply@{\pgfplots@i}{\pgfplots@minor@tick@dist}%
 						\else


### PR DESCRIPTION
Closes #180.

A smaller value like `1.1\H` would probably also do the trick, but I didn't want to take any chances.

Am I correct in surmising that there is no changelog (that is still maintained) where I should record the change?