### PR TITLE
doc: libs.statistics: i runs till N, not N - 1

### DIFF
--- a/doc/latex/pgfplots/pgfplots.libs.statistics.tex
+++ b/doc/latex/pgfplots/pgfplots.libs.statistics.tex
@@ -1007,7 +1007,7 @@ wish to change fill colors.
     computes the $N+1$ points $\underline m =: x_0 < x_1 < \dotsb < x_N :=
     \overline m$ using $x_i := \underline m + i \cdot (\overline m - \underline
     m)/N$. Then, it creates the $N+1$ coordinates $(x_i, y_i)$,
-    $i=0,\dotsc,N-1$ by means of
+    $i=0,\dotsc,N$ by means of
     %
         \[
             y_i :=


### PR DESCRIPTION
Creating N + 1 coordinates requires that i runs till N, and not N -
1. Otherwise, the case distinction below would never hit the i = N case.