### PR TITLE
doc: libs.statistics: drop superfluous \Bigr

### DIFF
--- a/doc/latex/pgfplots/pgfplots.libs.statistics.tex
+++ b/doc/latex/pgfplots/pgfplots.libs.statistics.tex
@@ -1012,7 +1012,7 @@ wish to change fill colors.
         \[
             y_i :=
                 \begin{cases}
-                    \text{bincount}\bigl([x_i,x_{i+1})\bigr)\Bigr)  & i < N \\
+                    \text{bincount}\bigl([x_i,x_{i+1})\bigr)        & i < N \\
                     y_{N-1}                                         & i = N,
                 \end{cases}
         \]


### PR DESCRIPTION
As suggested by Mo-Gul [1], this drops the superfluous \Bigr.

1: https://github.com/pgf-tikz/pgfplots/pull/498#issuecomment-2612627231