### PR TITLE
Make axis environment a pgfscope

### DIFF
--- a/tex/generic/pgfplots/pgfplots.code.tex
+++ b/tex/generic/pgfplots/pgfplots.code.tex
@@ -11770,7 +11770,7 @@
 %
 %
 \def\pgfplots@environment@opt[#1]{%
-	\begingroup
+	\pgfscope
 	\pgfplots@define@dummies@for@pseudoconstants
 	\pgfplotsifinaxis{%
 		\pgfplots@error{%
@@ -12154,7 +12154,7 @@
 		% \aftergroup does not hurt:
 		\aftergroup\pgf@remember@layerlist@globally
 	\fi
-	\endgroup
+	\endpgfscope
 	\pgfplots@glob@TMPa
 	%
 	% once more again - just to be sure that it works with LaTeX which


### PR DESCRIPTION
Rather than just a TeX group. This prevents changes to global variables like \pgflinewidth from leaking out of the axis environment.

Currently, an `axis` environment changes `\pgflinewidth` (and possibly other values) outside of the environment, leading to unexpected results with code that relies on that value being correct. For example, `circuitikz` uses this length to determine the component stroke width. After an `axis` (right resistor), this does not work correctly.
```latex
\documentclass{article}

\usepackage{tikz}
\usepackage{circuitikz}
\usepackage{pgfplots}
\pgfplotsset{compat=1.18}

\begin{document}

\begin{tikzpicture} [line width=2pt]
  \showthe\pgflinewidth
  \draw (-2,0) to [R] ++(2,0);
  \begin{axis} [anchor=north, yshift=-1cm]
    \addplot+ {x^2};
  \end{axis}
  \showthe\pgflinewidth
  \draw (0,0) to [R] ++(2,0);
\end{tikzpicture}

\end{document}
```
![image](https://github.com/user-attachments/assets/1aefed96-5443-4415-a367-4672b54d0360)

Using a `pgfscope` rather than a TeX group solves this problem.