### PR TITLE
docs: docu initial values

### DIFF
--- a/doc/latex/pgfplots/pgfplots.reference.errorbars.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.errorbars.tex
@@ -216,8 +216,8 @@ their own |error mark| and additional style arguments.
 \end{codeexample}
 \end{pgfplotsxykey}
 
-\begin{pgfplotskey}{error bars/error mark=\meta{marker}}
-    Sets an error marker for any error bar. \marg{marker} is expected to be a
+\begin{pgfplotskey}{error bars/error mark=\meta{marker} (initially |-|)}
+    Sets an error marker for any error bar. \meta{marker} is expected to be a
     valid plot mark, see Section~\ref{sec:markers}.
     %
 \begin{codeexample}[]
@@ -238,7 +238,7 @@ their own |error mark| and additional style arguments.
 \end{codeexample}
 \end{pgfplotskey}
 
-\begin{pgfplotskey}{error bars/error mark options=\marg{key-value-list}}
+\begin{pgfplotskey}{error bars/error mark options=\marg{key-value-list} (initially |rotate=90|)}
     Sets a key--value list of options for any error mark. This option works
     similarly to the \Tikz{} `|mark options|' key.
 \end{pgfplotskey}

--- a/doc/latex/pgfplots/pgfplots.reference.errorbars.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.errorbars.tex
@@ -216,7 +216,7 @@ their own |error mark| and additional style arguments.
 \end{codeexample}
 \end{pgfplotsxykey}
 
-\begin{pgfplotskey}{error bars/error mark=\meta{marker} (initially |-|)}
+\begin{pgfplotskey}{error bars/error mark=\meta{marker} (initially -)}
     Sets an error marker for any error bar. \meta{marker} is expected to be a
     valid plot mark, see Section~\ref{sec:markers}.
     %
@@ -238,7 +238,7 @@ their own |error mark| and additional style arguments.
 \end{codeexample}
 \end{pgfplotskey}
 
-\begin{pgfplotskey}{error bars/error mark options=\marg{key-value-list} (initially |rotate=90|)}
+\begin{pgfplotskey}{error bars/error mark options=\marg{key-value-list} (initially rotate=90)}
     Sets a key--value list of options for any error mark. This option works
     similarly to the \Tikz{} `|mark options|' key.
 \end{pgfplotskey}

--- a/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
@@ -2527,7 +2527,7 @@ target pos={10,100,200,500,1000,1100,1200,1500,2000,2895}
 \subsection{Cycle Lists -- Options Controlling Line Styles}
 \label{sec:cycle:list}
 
-\begin{pgfplotskeylist}{cycle list=\marg{list},cycle list name=\marg{name} (initially |color|)}
+\begin{pgfplotskeylist}{cycle list=\marg{list},cycle list name=\marg{name} (initially color)}
     Allows to specify a list of plot specifications which will be used for each
     \hbox{|\addplot|} command without explicit plot specification. Thus, the
     currently active |cycle list| will be used if you write either

--- a/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
+++ b/doc/latex/pgfplots/pgfplots.reference.markers-meta.tex
@@ -2527,7 +2527,7 @@ target pos={10,100,200,500,1000,1100,1200,1500,2000,2895}
 \subsection{Cycle Lists -- Options Controlling Line Styles}
 \label{sec:cycle:list}
 
-\begin{pgfplotskeylist}{cycle list=\marg{list},cycle list name=\marg{name}}
+\begin{pgfplotskeylist}{cycle list=\marg{list},cycle list name=\marg{name} (initially |color|)}
     Allows to specify a list of plot specifications which will be used for each
     \hbox{|\addplot|} command without explicit plot specification. Thus, the
     currently active |cycle list| will be used if you write either


### PR DESCRIPTION
Fixes #371.

Before

<img width="1140" height="170" alt="image" src="https://github.com/user-attachments/assets/0666d0c8-f4aa-4f20-bfa6-007d911c159e" />

<img width="1122" height="81" alt="image" src="https://github.com/user-attachments/assets/83f20bf3-6406-4b85-96c0-211eb66efd06" />

<img width="1119" height="100" alt="image" src="https://github.com/user-attachments/assets/5df65bd3-2da0-40f2-9d9b-c8c7a68573d8" />

After

<img width="1170" height="168" alt="image" src="https://github.com/user-attachments/assets/143e09d8-e6b0-4aaa-9497-76fb9e53226d" />

<img width="1134" height="86" alt="image" src="https://github.com/user-attachments/assets/b3e5be99-ee98-4440-afb6-9b239b473697" />

<img width="1142" height="115" alt="image" src="https://github.com/user-attachments/assets/5613f57c-141e-4d92-9647-12bff86451ce" />
