### PR TITLE
ci: build and deploy the pgfplots example gallery

### DIFF
--- a/.github/workflows/gallery.sh
+++ b/.github/workflows/gallery.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "::group::Install system dependencies"
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends imagemagick
+for policy in /etc/ImageMagick-*/policy.xml; do
+	[[ -f "${policy}" ]] || continue
+	sed -i -E 's@(<policy domain="coder" rights=")none("[^>]*pattern="PDF")@\1read|write\2@' "${policy}"
+done
+echo "::endgroup::"
+
+echo "::group::Set up TeX Live environment"
+tlmgr install acrotex
+echo "::endgroup::"
+
+echo "::group::Create TeX Live usertree"
+if ! [[ -d tlpkg/ ]]; then
+	tlmgr init-usertree --usertree "${PWD}"
+fi
+export "TEXMFHOME=${PWD}"
+echo "::endgroup::"
+
+echo "::group::Build the gallery"
+if ! nproc="$(nproc)"; then
+	nproc=1
+fi
+make -j "${nproc}" -C doc/latex/pgfplots/gallery all
+echo "::endgroup::"
+
+echo "::group::Assemble the gallery for deployment"
+rm -rf public
+mkdir -p public
+cp doc/latex/pgfplots/gallery/gallery.css public/
+cp doc/latex/pgfplots/gallery/gallery.html public/
+cp doc/latex/pgfplots/gallery/example_* public/
+cat > public/index.html <<'EOF'
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <noscript><meta http-equiv="refresh" content="0; url=http://pgfplots.sourceforge.net/"></noscript>
+  </head>
+  <body onload="window.location.replace('http://pgfplots.sourceforge.net/')">
+    If you are not redirected automatically, click <a href="http://pgfplots.sourceforge.net/">this link</a>.
+  </body>
+</html>
+EOF
+touch public/.nojekyll
+echo "::endgroup::"

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -1,0 +1,31 @@
+name: Gallery
+
+on: [push, pull_request]
+
+env:
+  TERM: "xterm-256color"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.gitlab.com/islandoftex/images/texlive:latest
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Fixup Run actions/checkout
+      run: git config --global --add safe.directory '*'
+
+    - name: Build the gallery
+      run: bash .github/workflows/gallery.sh
+
+    - name: Deploy pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages
+        folder: public
+        single-commit: true
+        dry-run: ${{ !(github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}

--- a/doc/latex/pgfplots/gallery/extractexamples.pl
+++ b/doc/latex/pgfplots/gallery/extractexamples.pl
@@ -51,7 +51,32 @@ $header =
 % http://www.ctan.org/tex-archive/graphics/pgf/contrib/pgfplots/doc/latex/plotdata/
 
 \usepackage{pgfplots}
+\usepackage{pgfplotstable}
 \pgfplotsset{compat=newest}
+
+% The manual loads these libraries globally; the extracted standalone examples
+% need them too. external/clickable/snakes are intentionally omitted.
+\usetikzlibrary{
+	arrows.meta,backgrounds,calc,decorations.footprints,decorations.markings,
+	decorations.pathreplacing,fixedpointarithmetic,intersections,patterns,
+	plotmarks,shapes.arrows,spy,through}
+\usepgfplotslibrary{
+	colorbrewer,colormaps,dateplot,fillbetween,groupplots,patchplots,polar,
+	smithchart,statistics,ternary,units}
+
+% Some colormap examples reuse this display style defined earlier in the manual.
+\pgfplotsset{
+	cycle from colormap manual style/.style={
+		x=3cm,y=10pt,ytick=\empty,
+		colorbar style={x=,y=,ytick=\empty},
+		point meta min=0,point meta max=1,
+		stack plots=y,
+		y dir=reverse,colorbar style={y dir=reverse},
+		every axis plot/.style={line width=2pt},
+		legend entries={0,...,20},
+		legend pos=outer north east,
+	},
+}
 
 \pagestyle{empty}
 ';
@@ -148,6 +173,9 @@ for($j = 2; $j<=$#ARGV; ++$j ) {
 		$prefix = "" if not defined($prefix);
 		next if ($prefix =~ m/NO GALLERY/);
 		$prefix =~ s/% //;
+		# Only a preamble directive (a LaTeX command) belongs in the output;
+		# ignore prose notes like "% FIXME ...".
+		$prefix = "" unless $prefix =~ m/^\s*\\/;
 
 		$possiblecomment = $matches[4*$q+1];
 		$possiblecomment = "" if not defined($possiblecomment);


### PR DESCRIPTION
Add .github/workflows/gallery.{yml,sh}: build the example gallery in the islandoftex TeX Live container and deploy it to GitHub Pages. index.html only redirects to the pgfplots home page; the gallery itself is served at gallery.html.

Fix extractexamples.pl so the extracted standalone examples compile: load the TikZ/pgfplots libraries and pgfplotstable that the manual provides globally, add the shared "cycle from colormap manual style" definition, and drop non-directive prose comments preceding a codeexample.