### PR TITLE
fix: use \jobname for insDLJS

### DIFF
--- a/.github/workflows/manual.sh
+++ b/.github/workflows/manual.sh
@@ -29,8 +29,11 @@ echo "::endgroup::"
 echo "::group::Build the manual"
 cd doc/latex/pgfplots
 thisrun=0
+if ! nproc="$(nproc)"; then
+	nproc=1
+fi
 while : ; do
-	make LATEX="lualatex -shell-escape -halt-on-error -interaction=nonstopmode"
+	make -j "${nproc}" LATEX="lualatex -shell-escape -halt-on-error -interaction=nonstopmode"
 	if ! grep -q -E "(There were undefined references|Rerun to get (cross-references|the bars) right)" -- *.log; then
 		break
 	fi

--- a/tex/latex/pgfplots/libs/tikzlibrarypgfplots.clickable.code.tex
+++ b/tex/latex/pgfplots/libs/tikzlibrarypgfplots.clickable.code.tex
@@ -223,7 +223,7 @@
 % The problem: insdljs creates a macro named 'dlsj\jobname' or
 % something like that, but if fails to use '\csname' properly. So:
 % only normal letters are allowed inside of the argument here.
-\begin{insDLJS}[processAnnotatedPlot]{pgfplotsJS}{pgfplots Clickable Plot Code}
+\edef\pgf@temp{\noexpand\begin{insDLJS}[processAnnotatedPlot]{\detokenize\expandafter{\jobname}}{pgfplots Clickable Plot Code}}\pgf@temp
 /*********************************************************************************
  * function sprintf() - written by Kevin van Zonneveld as part of the php to javascript
  * conversion project.


### PR DESCRIPTION
Previously every document would write pgfplotsJS.djs which resulted in a race condition when multiple documents were compiled in the same directory. By using \jobname, every document gets its own \jobname.djs and examples can be compiled massively parallel which drastically reduces the build time of the examples in "figures/expensiveexamples".